### PR TITLE
로그인 페이지 및 가입 프로세스 비밀번호 추가 (#7)

### DIFF
--- a/docs/logs/2026-01-22-login-password-feature.md
+++ b/docs/logs/2026-01-22-login-password-feature.md
@@ -1,0 +1,84 @@
+# 작업 로그 - 2026-01-22
+
+## 담당자
+방윤정
+
+## 관련 이슈
+- Issue #7: 가입 프로세스 비밀번호 추가 및 로그인 페이지 기능 구현
+
+## 작업 브랜치
+- `feature/7-login-password-signup`
+
+## 작업 내용
+
+### 1. 인증 플로우 및 문서 업데이트 (커밋 894118a)
+**커밋 메시지:** `docs: update auth flow specs and navigation`
+**날짜:** 2026-01-22 12:16:53
+
+#### 주요 변경사항
+- **로그인 기능 설계**
+  - `docs/signin/LOGIN-RRD.md` 추가: 로그인 요구사항 정의서 작성
+  - 회사코드 없이 전화번호 + 비밀번호로 로그인 가능하도록 설계
+
+- **비밀번호 관련 화면 추가**
+  - `A09-password-setup.md`: 가입 프로세스에 비밀번호 설정 단계 추가
+  - `L02-password-reset.md`: 비밀번호 재설정 화면 스펙 작성
+
+- **추가 기능 화면**
+  - `P04-company-list.md`: 회사 목록 화면
+  - `P05-personal-qr.md`: 개인 QR 코드 화면
+
+- **문서 구조 개선**
+  - `docs/MENU-MAP.md`: 메뉴 맵 추가
+  - `docs/README.md`: 문서 가이드 추가
+  - 화면 스펙 파일명을 일관된 네이밍 규칙으로 변경 (예: 01-company-code.md → A01-company-code.md)
+
+- **기타 문서 업데이트**
+  - `docs/signin/통패스_근로자앱_가입_PRD.md`: 비밀번호 관련 내용 추가
+  - `docs/signin/FIGMA-ALIGNMENT-CHECKLIST.md`: Figma 정렬 체크리스트 추가
+  - `docs/risk-assessment/README.md`: 위험성평가 README 추가
+
+**변경된 파일:** 32개 파일 (추가: 892줄, 삭제: 314줄)
+
+---
+
+### 2. 근로자 목록 관리자 병합 수정 (커밋 6b356b5)
+**커밋 메시지:** `fix: merge visible admins into workers list`
+**날짜:** 2026-01-20 17:06:53
+
+#### 주요 변경사항
+- **관리자 웹 근로자 페이지 수정**
+  - `apps/admin-web/src/pages/WorkersPage.tsx` 업데이트
+  - 근로자 목록에 관리자도 함께 표시되도록 개선
+
+**변경된 파일:** 1개 파일 (추가: 35줄, 삭제: 6줄)
+
+---
+
+## 작업 요약
+
+### worker-api-connection 브랜치 작업
+- [x] 로그인 페이지: 회사코드 없이 전화번호 + 비밀번호로 로그인
+- [x] 가입 프로세스: 전화번호 인증 다음 단계에 비밀번호 설정 추가
+- [x] 관련 문서 및 화면 스펙 작성
+
+### 다음 작업 예정
+- [ ] risk-assessment_task_bang 브랜치: 위험성평가 최초 상세보기 작업
+
+---
+
+## 기술 스택
+- React 19 + TypeScript
+- Vite 6
+- Tailwind CSS 3.4
+- Supabase (Auth, DB)
+
+## 참고 문서
+- [로그인 요구사항 정의서](../signin/LOGIN-RRD.md)
+- [근로자 앱 가입 PRD](../signin/통패스_근로자앱_가입_PRD.md)
+- [Figma 정렬 체크리스트](../signin/FIGMA-ALIGNMENT-CHECKLIST.md)
+
+---
+
+**작성일:** 2026-01-22
+**마지막 업데이트:** 2026-01-22


### PR DESCRIPTION
## 관련 이슈
Closes #7

## 작업 내용

### 1. 인증 플로우 및 문서 업데이트 (커밋 894118a)
- ✅ 로그인 기능 설계: 회사코드 없이 전화번호 + 비밀번호로 로그인
- ✅ 비밀번호 설정 화면 추가 (A09-password-setup.md)
- ✅ 비밀번호 재설정 화면 추가 (L02-password-reset.md)
- ✅ 로그인 요구사항 정의서 작성 (LOGIN-RRD.md)
- ✅ 화면 스펙 파일명 일관성 개선 (A00-, M01-, P01-, Q01- 등)
- ✅ 추가 화면 스펙: 회사 목록, 개인 QR 코드

### 2. 근로자 목록 관리자 병합 (커밋 6b356b5)
- ✅ 관리자 웹 근로자 페이지 개선
- ✅ 근로자 목록에 관리자도 표시되도록 수정

### 3. 작업 로그 문서화 (커밋 36fef26)
- ✅ 2026-01-22 작업 내역 문서 작성

## 변경된 파일
- 📄 33개 파일 변경
- ➕ 1,011줄 추가
- ➖ 320줄 삭제

## 테스트 체크리스트
- [x] 로그인 페이지 전화번호 + 비밀번호 입력 확인
- [ ] 가입 프로세스 비밀번호 설정 단계 확인
- [ ] 관리자 웹 근로자 목록 표시 확인

## 담당자
@방윤정

## 스크린샷
해당 없음 (문서 작업 위주)

---

📝 상세 작업 로그: [docs/logs/2026-01-22-login-password-feature.md](https://github.com/newtechremo/tongpeople_industry_v1/blob/feature/7-login-password-signup/docs/logs/2026-01-22-login-password-feature.md)