### PR TITLE
feat: 위험성평가 테이블 정리 및 UI 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,10 @@ apps/TongPassApp/__tests__/__snapshots__/
 
 # Mock server
 apps/TongPassApp/mock-server/node_modules/
+*.tsbuildinfo
+
+# Claude Code local settings
+.claude/settings.local.json
+
+# Supabase local branches
+backend/supabase/.branches/

--- a/.sisyphus/drafts/initial-risk-assessment-improvements.md
+++ b/.sisyphus/drafts/initial-risk-assessment-improvements.md
@@ -1,0 +1,508 @@
+# 최초 위험성평가 개선 작업 계획
+
+**작성일**: 2026-01-26
+**브랜치**: `feature/14-risk-assessment-ui-improvements` (계속 사용)
+**목표**: 최초 위험성평가를 기준으로 3가지 핵심 기능 추가
+
+---
+
+## 📋 배경 및 목표
+
+### 현재 상황
+- **최초 위험성평가** (InitialAssessmentForm): 474줄, 가장 완성도 높음
+- **수시 위험성평가** (AdHocAssessmentForm): 267줄, 미완성 상태
+- 수시 평가에는 이미 페이지네이션 + AI 추천 적용됨 (이번 작업에서)
+- 최초 평가에는 적용 안 됨 (별도의 RiskFactorSelectModal 사용)
+
+### 전략
+1. **Phase 1**: 최초 위험성평가에 3가지 기능 추가
+   - 소분류 검색
+   - 위험요인 페이지네이션
+   - AI 추천
+2. **Phase 2**: 최초 평가 문서 및 구조 파악
+3. **Phase 3**: 수시 평가를 최초 기반으로 재작성 (추후)
+
+---
+
+## 🎯 Phase 1: 최초 위험성평가 핵심 기능 추가
+
+### 목표
+최초 위험성평가를 완전한 기준으로 만들기 위해 3가지 기능 추가
+
+### 작업 범위
+
+#### 1. 소분류 검색 기능 추가
+**대상 컴포넌트**: `SubcategoryCheckList`
+**현재 상태**: 검색 기능 없음, 체크박스만
+**작업 내용**:
+- ✅ 이미 완료됨 (이번 작업에서 추가함)
+- 검증만 필요
+
+#### 2. 위험요인 페이지네이션 추가
+**대상 컴포넌트**: `RiskFactorSelectModal`
+**현재 상태**: 전체 목록 한 번에 표시
+**작업 내용**:
+- 페이지당 20개 표시
+- 이전/다음 버튼
+- 현재 페이지/총 페이지 표시
+- 검색 시 첫 페이지로 리셋
+
+**참고**: `RiskFactorSelector`에 이미 구현된 로직 참고
+
+#### 3. AI 추천 기능 추가
+**대상 컴포넌트**: `RiskFactorSelectModal`
+**현재 상태**: AI 추천 없음
+**작업 내용**:
+- ai-recommendations.ts 연동
+- AI 추천 섹션 (오렌지 배경)
+- 배지 + 순위 + 점수 표시
+- 추천 근거 표시
+- 로딩 상태 처리 (500ms 시뮬레이션)
+
+**참고**: `RiskFactorSelector`에 이미 구현된 UI 참고
+
+---
+
+## 📁 Phase 1 작업 파일
+
+### 수정할 파일
+1. `apps/admin-web/src/pages/risk-assessment/modals/RiskFactorSelectModal.tsx`
+   - 페이지네이션 로직 추가
+   - AI 추천 섹션 추가
+   - UI 개선
+
+### 참고할 파일
+1. `apps/admin-web/src/components/risk-assessment/inputs/RiskFactorSelector.tsx`
+   - 페이지네이션 구현 참고
+   - AI 추천 UI 참고
+
+2. `apps/admin-web/src/mocks/ai-recommendations.ts`
+   - 이미 생성된 Mock 데이터 활용
+
+---
+
+## 🛠 Phase 1 상세 구현 계획
+
+### Step 1: 현재 RiskFactorSelectModal 구조 분석
+**예상 시간**: 30분
+
+```typescript
+// 현재 구조
+- Mock 데이터: mockFactors (5개)
+- 검색 기능: 있음 (searchQuery)
+- 선택 방식: 체크박스 (selectedIds)
+- 모드: 'search' | 'direct'
+```
+
+**확인 사항**:
+- Props 구조
+- 상태 관리 방식
+- 검색 필터링 로직
+- 제출 로직
+
+### Step 2: 페이지네이션 추가
+**예상 시간**: 1-1.5시간
+
+**상태 추가**:
+```typescript
+const [currentPage, setCurrentPage] = useState(1);
+const itemsPerPage = 20;
+```
+
+**페이지네이션 로직**:
+```typescript
+const totalPages = Math.ceil(filteredFactors.length / itemsPerPage);
+const paginatedFactors = filteredFactors.slice(
+  (currentPage - 1) * itemsPerPage,
+  currentPage * itemsPerPage
+);
+```
+
+**핸들러**:
+```typescript
+const handlePrevPage = () => setCurrentPage(prev => Math.max(1, prev - 1));
+const handleNextPage = () => setCurrentPage(prev => Math.min(totalPages, prev + 1));
+const handleSearch = (query: string) => {
+  setSearchQuery(query);
+  setCurrentPage(1); // 검색 시 첫 페이지로
+};
+```
+
+**UI 추가**:
+```tsx
+{filteredFactors.length > 0 && totalPages > 1 && (
+  <div className="flex items-center justify-center gap-4 py-3 border-t-2 border-gray-200 mt-4">
+    <button onClick={handlePrevPage} disabled={currentPage === 1}>
+      ◀ 이전
+    </button>
+    <span>{currentPage} / {totalPages} 페이지</span>
+    <button onClick={handleNextPage} disabled={currentPage === totalPages}>
+      다음 ▶
+    </button>
+  </div>
+)}
+```
+
+### Step 3: AI 추천 기능 통합
+**예상 시간**: 1.5-2시간
+
+**Import 추가**:
+```typescript
+import { getAIRecommendations, type AIRecommendation } from '@/mocks/ai-recommendations';
+import { Loader2 } from 'lucide-react';
+```
+
+**상태 추가**:
+```typescript
+const [aiRecommendations, setAiRecommendations] = useState<AIRecommendation[]>([]);
+const [isLoadingAI, setIsLoadingAI] = useState(false);
+```
+
+**AI 추천 로드**:
+```typescript
+useEffect(() => {
+  if (isOpen && categoryId && subcategoryId) {
+    loadMockAIRecommendations();
+  }
+}, [isOpen, categoryId, subcategoryId]);
+
+const loadMockAIRecommendations = () => {
+  setIsLoadingAI(true);
+  setTimeout(() => {
+    const recommendations = getAIRecommendations(categoryId, subcategoryId, 10);
+    setAiRecommendations(recommendations);
+    setIsLoadingAI(false);
+  }, 500);
+};
+```
+
+**UI 추가** (검색창 아래, 일반 목록 위):
+```tsx
+{/* AI 추천 섹션 */}
+{aiRecommendations.length > 0 && !searchQuery && (
+  <div className="mb-4">
+    <h4 className="text-sm font-bold text-orange-600 mb-3">
+      🤖 AI 추천 위험요인
+    </h4>
+    <div className="space-y-2 max-h-64 overflow-y-auto">
+      {aiRecommendations.map((rec, index) => (
+        <label className="...오렌지 배경...">
+          <input type="checkbox" ... />
+          <div>
+            <span className="badge">AI 추천 #{index + 1}</span>
+            <span>{rec.score}점</span>
+            <div>{rec.riskFactor}</div>
+            <div>📊 {rec.reason}</div>
+          </div>
+        </label>
+      ))}
+    </div>
+    <div className="mt-2 border-t-2"></div>
+  </div>
+)}
+
+{/* 로딩 상태 */}
+{isLoadingAI && !aiRecommendations.length && (
+  <div className="p-8 text-center">
+    <Loader2 className="animate-spin" />
+    <p>AI가 추천 위험요인을 분석 중입니다...</p>
+  </div>
+)}
+
+{/* 일반 위험요인 제목 */}
+{aiRecommendations.length > 0 && !searchQuery && (
+  <h4 className="text-sm font-bold text-slate-600 mb-3">일반 위험요인</h4>
+)}
+```
+
+**주의사항**:
+- AI 추천 항목도 `selectedIds`에 포함시켜야 함
+- AI 추천 id는 9000번대, 일반 항목은 1~100번대로 구분
+- Mock 데이터와 실제 mockFactors의 id 충돌 방지
+
+### Step 4: 디자인 통일 및 테스트
+**예상 시간**: 30분-1시간
+
+**디자인 체크리스트**:
+- [ ] RiskFactorSelector와 동일한 페이지네이션 UI
+- [ ] AI 추천 섹션 오렌지 테마 일관성
+- [ ] 배지 디자인 통일
+- [ ] 버튼 스타일 통일
+
+**테스트 시나리오**:
+1. 최초 위험성평가 만들기 페이지 진입
+2. 대분류 선택 → 소분류 선택
+3. 위험요인 추가 버튼 클릭
+4. AI 추천 로딩 확인 (500ms)
+5. AI 추천 항목 표시 확인
+6. 일반 위험요인 페이지네이션 확인 (20개씩)
+7. 이전/다음 버튼 동작 확인
+8. 검색 시 페이지 1로 리셋 확인
+9. AI 추천 + 일반 항목 동시 선택 가능 확인
+10. 선택 후 추가 버튼 클릭 → 정상 추가 확인
+
+---
+
+## 🎯 Phase 2: 최초 위험성평가 문서 파악
+
+### 목표
+현재 최초 위험성평가의 구조와 기능을 완전히 이해
+
+### 작업 내용
+
+#### 1. 기존 문서 검토
+**파일 확인**:
+```
+docs/ui-specs/pc/specs/2026-01-20-최초위험성평가만들기-구현상세.md
+docs/risk-assessment/위험성평가_기획서.md
+docs/risk-assessment/위험성평가_개발명세서.md
+```
+
+**확인 사항**:
+- 데이터 구조
+- 필수 입력 항목
+- 유효성 검사 규칙
+- 제출 플로우
+- API 명세 (예정)
+
+#### 2. 코드 구조 분석
+**InitialAssessmentForm.tsx (474줄) 분석**:
+```
+1. 상태 관리
+   - categories: Category[]
+   - activeCategory, activeSubcategory
+   - Modal 상태들
+
+2. 핸들러 함수
+   - handleAddCategory
+   - handleCategoryChange
+   - handleSubcategoryToggle
+   - handleAddRiskFactor
+   - handleSubmit
+
+3. 컴포넌트 구조
+   - BasicInfoSection
+   - CategoryItem (반복)
+     - SubcategoryCheckList
+     - RiskFactorCard (반복)
+   - 모달들
+```
+
+#### 3. 개선 필요 영역 식별
+**예상 개선 사항**:
+- [ ] 중복 코드 제거
+- [ ] 상태 관리 단순화
+- [ ] 타입 안전성 강화
+- [ ] 컴포넌트 분리
+- [ ] 에러 처리 개선
+
+---
+
+## 🎯 Phase 3: 수시 위험성평가 재작성 (추후)
+
+### 목표
+최초 위험성평가를 기반으로 수시 평가 재작성
+
+### 전략
+
+#### 1. 공통 컴포넌트 추출
+**새로운 공통 컴포넌트**:
+```
+components/risk-assessment/shared/
+├── AssessmentFormLayout.tsx      # 공통 레이아웃
+├── CategorySelector.tsx           # 대분류 선택
+├── SubcategorySelector.tsx        # 소분류 선택
+├── RiskFactorManager.tsx          # 위험요인 관리
+└── AssessmentSubmitSection.tsx   # 제출 섹션
+```
+
+#### 2. 타입 공통화
+**shared 패키지로 이동**:
+```typescript
+// packages/shared/src/types/risk-assessment.ts
+export interface RiskFactor { ... }
+export interface Subcategory { ... }
+export interface Category { ... }
+export interface AssessmentFormData { ... }
+```
+
+#### 3. 수시 평가 특화 기능
+**수시만의 차이점**:
+- 수시 사유 입력 (TriggerReasonFieldset)
+- 작업 기간 입력 (WorkPeriodFieldset)
+- 빈도/강도 평가 (FrequencyIntensityFieldset)
+
+**재작성 방식**:
+```tsx
+// 새로운 AdHocAssessmentForm
+export default function AdHocAssessmentForm() {
+  return (
+    <AssessmentFormLayout type="adhoc">
+      <BasicInfoSection />
+      <TriggerReasonFieldset />      {/* 수시 전용 */}
+      <WorkPeriodFieldset />          {/* 수시 전용 */}
+      <CategorySelector />            {/* 공통 */}
+      <SubcategorySelector />         {/* 공통 */}
+      <RiskFactorManager />           {/* 공통 */}
+      <FrequencyIntensityFieldset />  {/* 수시 전용 */}
+      <AssessmentSubmitSection />     {/* 공통 */}
+    </AssessmentFormLayout>
+  );
+}
+```
+
+---
+
+## 📊 예상 일정
+
+### Phase 1: 최초 평가 기능 추가
+| 단계 | 작업 | 예상 시간 |
+|------|------|-----------|
+| Step 1 | 구조 분석 | 30분 |
+| Step 2 | 페이지네이션 추가 | 1-1.5시간 |
+| Step 3 | AI 추천 통합 | 1.5-2시간 |
+| Step 4 | 디자인 통일 및 테스트 | 30분-1시간 |
+| **합계** | | **3.5-5시간** |
+
+### Phase 2: 문서 파악
+| 단계 | 작업 | 예상 시간 |
+|------|------|-----------|
+| 문서 검토 | 기존 문서 읽기 | 1시간 |
+| 코드 분석 | InitialAssessmentForm 분석 | 1-2시간 |
+| 개선 계획 | 리팩토링 계획 수립 | 1시간 |
+| **합계** | | **3-4시간** |
+
+### Phase 3: 수시 평가 재작성 (추후)
+| 단계 | 작업 | 예상 시간 |
+|------|------|-----------|
+| 공통 컴포넌트 | 추출 및 리팩토링 | 4-6시간 |
+| 수시 재작성 | 새로운 AdHocAssessmentForm | 2-3시간 |
+| 테스트 | 통합 테스트 | 1-2시간 |
+| **합계** | | **7-11시간** |
+
+---
+
+## 🚨 주의사항
+
+### Phase 1 작업 시
+1. **기존 기능 보존**
+   - RiskFactorSelectModal의 'direct' 모드 유지
+   - 커스텀 소분류 처리 로직 유지
+   - existingFactors 중복 제거 로직 유지
+
+2. **Mock 데이터 통합**
+   - ai-recommendations.ts의 id는 9000번대
+   - mockFactors의 id는 1~100번대
+   - selectedIds는 두 타입 모두 포함
+
+3. **디자인 일관성**
+   - RiskFactorSelector와 동일한 UI
+   - 오렌지 테마 유지
+   - 배지/버튼 스타일 통일
+
+### Phase 2 작업 시
+1. **기존 기능 파악 우선**
+   - 섣부른 리팩토링 지양
+   - 모든 기능 완전히 이해 후 계획 수립
+
+2. **문서화 철저**
+   - 발견한 모든 로직 문서화
+   - 개선 필요 영역 명확히 정리
+
+### Phase 3 작업 시
+1. **점진적 마이그레이션**
+   - 한 번에 모두 바꾸지 말고 단계적으로
+   - 각 단계마다 테스트
+
+2. **하위 호환성 유지**
+   - 기존 데이터 구조 유지
+   - API 호출 형식 유지
+
+---
+
+## ✅ 성공 기준
+
+### Phase 1
+- [ ] 소분류 검색 정상 동작
+- [ ] 위험요인 페이지네이션 20개씩 표시
+- [ ] AI 추천 항목 상단 표시 (오렌지 배경)
+- [ ] 페이지 이동 정상 동작
+- [ ] 검색 시 페이지 1로 리셋
+- [ ] AI 추천 + 일반 항목 동시 선택 가능
+- [ ] 디자인 일관성 유지
+- [ ] 기존 기능 모두 정상 동작
+
+### Phase 2
+- [ ] 모든 문서 검토 완료
+- [ ] InitialAssessmentForm 코드 완전히 이해
+- [ ] 개선 계획 문서 작성
+- [ ] 리팩토링 우선순위 결정
+
+### Phase 3 (추후)
+- [ ] 공통 컴포넌트 정상 동작
+- [ ] 수시 평가 정상 작성 가능
+- [ ] 최초/수시 모두 동일한 UX
+- [ ] 코드 중복 50% 이상 감소
+- [ ] 타입 안전성 100%
+
+---
+
+## 🔄 작업 플로우
+
+### Phase 1 실행 단계
+```
+1. RiskFactorSelectModal.tsx 읽기
+   ↓
+2. 페이지네이션 로직 추가
+   ↓
+3. AI 추천 상태 및 로직 추가
+   ↓
+4. UI 섹션 추가 (AI 추천)
+   ↓
+5. 디자인 조정 및 통일
+   ↓
+6. 브라우저 테스트
+   ↓
+7. 커밋
+```
+
+### Phase 2 실행 단계
+```
+1. 문서 읽기 (3개 파일)
+   ↓
+2. InitialAssessmentForm.tsx 정독
+   ↓
+3. 각 함수/컴포넌트 역할 정리
+   ↓
+4. 개선 필요 영역 식별
+   ↓
+5. 리팩토링 계획 문서 작성
+   ↓
+6. 사용자와 논의 후 Phase 3 계획 수립
+```
+
+---
+
+## 📝 변경 로그 (작업 후 작성)
+
+### Phase 1
+- [ ] RiskFactorSelectModal 페이지네이션 추가
+- [ ] RiskFactorSelectModal AI 추천 통합
+- [ ] 디자인 통일
+- [ ] 테스트 완료
+
+### Phase 2
+- [ ] 문서 검토 완료
+- [ ] 코드 분석 완료
+- [ ] 개선 계획 수립
+
+### Phase 3 (추후)
+- [ ] 공통 컴포넌트 추출
+- [ ] 수시 평가 재작성
+- [ ] 통합 테스트
+
+---
+
+**작성자**: Prometheus (Planning Agent)
+**승인 대기**: 사용자 확인 후 Phase 1 실행
+**다음 단계**: Phase 1 → Phase 2 → 사용자와 논의 → Phase 3

--- a/.sisyphus/drafts/risk-assessment-ui-improvements.md
+++ b/.sisyphus/drafts/risk-assessment-ui-improvements.md
@@ -1,0 +1,510 @@
+# 위험성평가 UI 개선 작업 계획
+
+**작성일**: 2026-01-26
+**브랜치**: `feature/12-risk-assessment-approval-line`
+**목표**: 대규모 데이터 대응 + AI 추천 기능 통합
+
+---
+
+## 📋 요구사항 요약
+
+### 현재 문제점
+1. **소분류**: Mock 5개만 표시, 검색 없음 → 200개+ 데이터 대응 불가
+2. **위험요인 모달**: 전체 목록 한 번에 표시 → 스크롤 길어질 우려
+3. **AI 추천**: 기존 Python 엔진 있으나 UI에 미연동
+
+### 개선 목표
+1. ✅ 소분류 검색 기능 추가
+2. ✅ 위험요인 모달 페이지네이션 (20개씩)
+3. ✅ AI 추천 기능 UI 통합
+4. ✅ 디자인 일관성 유지 (오렌지 그라데이션 테마)
+
+---
+
+## 🎯 작업 범위
+
+### Phase 1: 소분류 검색 기능 추가
+**예상 소요**: 1-2시간
+**우선순위**: HIGH
+
+**현재 구조**:
+```tsx
+// SubcategoryCheckList.tsx
+- 체크박스 리스트만 표시
+- Mock 데이터 5개
+- 검색 기능 없음
+```
+
+**개선 후**:
+```tsx
+- 검색창 추가 (대분류와 유사한 UI)
+- 실시간 필터링
+- 검색 결과 없을 때 안내 메시지
+- 체크박스 리스트 유지
+```
+
+---
+
+### Phase 2: 위험요인 모달 페이지네이션
+**예상 소요**: 2-3시간
+**우선순위**: HIGH
+
+**현재 구조**:
+```tsx
+// RiskFactorSelector.tsx
+- 모달 + 검색 + 체크박스
+- 전체 목록 한 번에 표시
+- filteredFactors.map() 전체 렌더링
+```
+
+**개선 후**:
+```tsx
+- 페이지당 20개 표시
+- 이전/다음 버튼
+- 현재 페이지/총 페이지 표시
+- 검색 시 페이지 1로 리셋
+```
+
+**UI 예시**:
+```
+┌─────────────────────────────────────────┐
+│ 위험요인 선택                    [닫기]  │
+├─────────────────────────────────────────┤
+│ [🔍 검색창]                             │
+├─────────────────────────────────────────┤
+│ ☐ 위험요인 1                            │
+│ ☐ 위험요인 2                            │
+│ ...                                     │
+│ ☐ 위험요인 20                           │
+├─────────────────────────────────────────┤
+│ [◀ 이전]  1 / 25 페이지  [다음 ▶]      │
+├─────────────────────────────────────────┤
+│ 5개 선택됨          [취소] [추가 (5)]   │
+└─────────────────────────────────────────┘
+```
+
+---
+
+### Phase 3: AI 추천 기능 UI (Mock 데이터)
+**예상 소요**: 2시간
+**우선순위**: MEDIUM
+
+> ⚠️ **주의**: 실제 백엔드 API 연동은 다른 개발자가 추후 진행
+> 현재는 Mock 데이터로 UI 프로토타입만 구현
+
+#### 3.1 Mock 데이터 정의
+**파일**: `apps/admin-web/src/mocks/ai-recommendations.ts` (새 파일)
+
+**Mock 데이터 구조**:
+```typescript
+export interface AIRecommendation {
+  id: number;
+  taskName: string;        // 작업명
+  riskFactor: string;      // 위험요인
+  accidentType: string;    // 재해형태
+  score: number;           // 추천 점수 (0-100)
+  reason: string;          // 추천 근거
+  improvement: string;     // 개선대책
+}
+
+// Mock 데이터 예시
+export const MOCK_AI_RECOMMENDATIONS: Record<string, AIRecommendation[]> = {
+  // 키: "{categoryId}-{subcategoryId}"
+  "1-101": [ // 건설업 - 가설전선 설치작업
+    {
+      id: 9001,
+      taskName: "가설전선 설치작업",
+      riskFactor: "안전대를 사용하지 않고 고소부위 작업중 추락",
+      accidentType: "떨어짐",
+      score: 90,
+      reason: "작업명 '가설전선' 매칭(40) + 고위험 '떨어짐'(30) + 복합매칭(20)",
+      improvement: "고소부위 작업시 안전대 고리 체결 철저"
+    },
+    {
+      id: 9002,
+      taskName: "전선작업",
+      riskFactor: "전선 접촉으로 인한 감전",
+      accidentType: "감전",
+      score: 70,
+      reason: "위험요인 '전선' 매칭(20) + 고위험 '감전'(30) + 복합매칭(20)",
+      improvement: "절연장갑 착용 및 전원 차단 후 작업"
+    },
+    // ... 더 많은 항목
+  ],
+  "1-102": [ // 건설업 - 가설전선 점검작업
+    // ...
+  ]
+};
+
+// 카테고리/소분류 조합으로 추천 조회
+export function getAIRecommendations(
+  categoryId: number,
+  subcategoryId: number,
+  limit: number = 10
+): AIRecommendation[] {
+  const key = `${categoryId}-${subcategoryId}`;
+  const recommendations = MOCK_AI_RECOMMENDATIONS[key] || [];
+  return recommendations.slice(0, limit);
+}
+```
+
+#### 3.2 프론트엔드 UI 구현
+**파일**: `apps/admin-web/src/components/risk-assessment/inputs/RiskFactorSelector.tsx`
+
+**UI 개선**:
+```tsx
+// 상단: AI 추천 항목 (오렌지 배경)
+┌─────────────────────────────────────────┐
+│ 🤖 AI 추천 위험요인                     │
+├─────────────────────────────────────────┤
+│ ☐ [#1 90점] 안전대 미착용 추락          │
+│   → 작업명 '가설전선' 매칭(40) + ...    │
+│ ☐ [#2 70점] 감전 사고                   │
+│   → 위험요인 '전선' 매칭(20) + ...      │
+├─────────────────────────────────────────┤
+│ 일반 위험요인                            │
+├─────────────────────────────────────────┤
+│ ☐ 기타 위험요인 1                        │
+│ ☐ 기타 위험요인 2                        │
+└─────────────────────────────────────────┘
+```
+
+**기능**:
+1. 모달 열릴 때 자동으로 AI 추천 API 호출
+2. 로딩 스피너 표시
+3. AI 추천 항목을 상단에 배치 (오렌지 배경 + 배지)
+4. 스코어 및 추천 근거 표시
+5. 일반 목록과 구분선으로 분리
+
+---
+
+## 🛠 기술 스펙
+
+### 상태 관리
+```typescript
+// RiskFactorSelector.tsx
+const [currentPage, setCurrentPage] = useState(1);
+const [aiRecommendations, setAiRecommendations] = useState<RiskFactorOption[]>([]);
+const [isLoadingAI, setIsLoadingAI] = useState(false);
+
+const itemsPerPage = 20;
+const totalPages = Math.ceil(filteredFactors.length / itemsPerPage);
+const paginatedFactors = filteredFactors.slice(
+  (currentPage - 1) * itemsPerPage,
+  currentPage * itemsPerPage
+);
+```
+
+### 페이지네이션 핸들러
+```typescript
+const handlePrevPage = () => {
+  setCurrentPage(prev => Math.max(1, prev - 1));
+};
+
+const handleNextPage = () => {
+  setCurrentPage(prev => Math.min(totalPages, prev + 1));
+};
+
+const handleSearch = (query: string) => {
+  setSearchQuery(query);
+  setCurrentPage(1); // 검색 시 첫 페이지로
+};
+```
+
+### AI 추천 Mock 데이터 로드
+```typescript
+import { getAIRecommendations } from '@/mocks/ai-recommendations';
+
+useEffect(() => {
+  if (isOpen && !isCustomSubcategory) {
+    loadMockAIRecommendations();
+  }
+}, [isOpen, categoryId, subcategoryId]);
+
+const loadMockAIRecommendations = () => {
+  setIsLoadingAI(true);
+
+  // Mock 데이터 로딩 시뮬레이션 (500ms 지연)
+  setTimeout(() => {
+    const recommendations = getAIRecommendations(categoryId, subcategoryId, 10);
+    setAiRecommendations(recommendations);
+    setIsLoadingAI(false);
+  }, 500);
+};
+
+// 추후 실제 API로 교체 시:
+// const fetchAIRecommendations = async () => {
+//   setIsLoadingAI(true);
+//   try {
+//     const response = await fetch('/api/risk-assessment/recommend', {
+//       method: 'POST',
+//       body: JSON.stringify({ categoryId, subcategoryId, limit: 10 })
+//     });
+//     const data = await response.json();
+//     setAiRecommendations(data.recommendations);
+//   } catch (error) {
+//     console.error('AI 추천 실패:', error);
+//   } finally {
+//     setIsLoadingAI(false);
+//   }
+// };
+```
+
+---
+
+## 📁 파일 변경 사항
+
+### 수정할 파일
+1. `apps/admin-web/src/pages/risk-assessment/components/SubcategoryCheckList.tsx`
+   - 검색창 추가
+   - 필터링 로직 구현
+
+2. `apps/admin-web/src/components/risk-assessment/inputs/RiskFactorSelector.tsx`
+   - 페이지네이션 로직 추가
+   - AI 추천 API 연동
+   - UI 개선 (AI 추천 섹션 추가)
+
+### 새로 생성할 파일
+3. `apps/admin-web/src/mocks/ai-recommendations.ts`
+   - AI 추천 Mock 데이터
+   - `getAIRecommendations()` 함수
+
+4. `apps/admin-web/src/hooks/useAIRecommendations.ts` (선택사항)
+   - AI 추천 로직 커스텀 훅 분리
+   - 추후 실제 API 교체 용이
+
+---
+
+## 🎨 디자인 가이드
+
+### 소분류 검색창
+```tsx
+<div className="relative mb-3">
+  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400" />
+  <input
+    type="text"
+    value={searchQuery}
+    onChange={(e) => setSearchQuery(e.target.value)}
+    placeholder="소분류 검색..."
+    className="w-full pl-10 pr-4 py-2 border-2 border-gray-200 rounded-lg focus:border-orange-500 focus:outline-none"
+  />
+</div>
+```
+
+### 페이지네이션 UI
+```tsx
+<div className="flex items-center justify-center gap-4 py-3 border-t-2 border-gray-200">
+  <button
+    onClick={handlePrevPage}
+    disabled={currentPage === 1}
+    className="px-4 py-2 rounded-lg font-medium text-slate-600 bg-gray-100 hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+  >
+    ◀ 이전
+  </button>
+
+  <span className="text-sm text-slate-600">
+    <span className="font-bold text-orange-600">{currentPage}</span> / {totalPages} 페이지
+  </span>
+
+  <button
+    onClick={handleNextPage}
+    disabled={currentPage === totalPages}
+    className="px-4 py-2 rounded-lg font-medium text-slate-600 bg-gray-100 hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+  >
+    다음 ▶
+  </button>
+</div>
+```
+
+### AI 추천 항목 배지
+```tsx
+<div className="bg-gradient-to-r from-orange-50 to-orange-100 border-2 border-orange-200 rounded-lg p-3">
+  <div className="flex items-start gap-3">
+    <input type="checkbox" ... />
+    <div className="flex-1">
+      <div className="flex items-center gap-2 mb-1">
+        <span className="px-2 py-0.5 bg-orange-500 text-white text-xs font-bold rounded">
+          🤖 AI 추천 #{rank}
+        </span>
+        <span className="text-xs text-orange-700 font-medium">
+          {score}점
+        </span>
+      </div>
+      <div className="font-bold text-slate-800">{riskFactor}</div>
+      <div className="text-xs text-slate-500 mt-1">
+        📊 {reason}
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+---
+
+## ✅ 테스트 시나리오
+
+### 소분류 검색
+1. 대분류 선택 → 소분류 목록 표시
+2. 검색창에 "가설" 입력
+3. "가설전선 설치작업", "가설전선 점검작업"만 표시
+4. 검색 결과 없을 때 안내 메시지 확인
+
+### 위험요인 페이지네이션
+1. 위험요인 추가 버튼 클릭
+2. 첫 페이지 (1-20개) 표시 확인
+3. "다음" 버튼 클릭 → 2페이지 (21-40개)
+4. "이전" 버튼 클릭 → 1페이지로 복귀
+5. 마지막 페이지에서 "다음" 버튼 비활성화 확인
+6. 검색 시 페이지 1로 리셋 확인
+
+### AI 추천
+1. 대분류 "건설업", 소분류 "가설전선 설치작업" 선택
+2. 위험요인 추가 모달 열기
+3. AI 추천 로딩 스피너 확인
+4. AI 추천 항목 상단 표시 (오렌지 배경)
+5. 스코어 높은 순 정렬 확인
+6. 추천 근거 표시 확인
+7. AI 추천 + 일반 항목 구분선 확인
+8. AI 추천 항목 체크 후 추가 가능 확인
+
+---
+
+## 🚨 주의사항
+
+### Mock 데이터 설계
+- 실제 API와 동일한 인터페이스 사용
+- 추후 백엔드 개발자가 쉽게 교체할 수 있도록 구조화
+- Mock 데이터에 충분한 예시 포함 (각 조합마다 5-10개)
+
+### 실제 API 연동 준비사항 (백엔드 개발자용)
+**추후 구현 필요**:
+1. Python `recommender.py` 호출 API 엔드포인트
+2. SQLite DB `safety_master.db` 연동
+3. 스코어링 알고리즘 적용
+4. DB 경로: `packages/shared/data/safety_master.db`
+
+**프론트엔드 수정 필요**:
+- `getAIRecommendations()` Mock 함수 → 실제 API 호출로 교체
+- 에러 처리 추가 (네트워크 오류, 타임아웃)
+
+### 성능 최적화
+- Mock 데이터 로딩 지연 시뮬레이션 (500ms) → 로딩 UX 테스트
+- 페이지네이션으로 DOM 노드 수 제한
+- AI 추천은 모달 열릴 때 한 번만 로드
+
+### 에러 처리
+- AI 추천 Mock 데이터 없을 시에도 일반 목록은 표시
+- 빈 검색 결과 안내 메시지
+
+---
+
+## 📦 Dependencies
+
+### 프론트엔드 (이미 설치됨)
+```json
+{
+  "lucide-react": "^0.263.1"
+}
+```
+
+### 백엔드 (추후 다른 개발자가 구현)
+- Python 3.8+
+- SQLite3
+- `recommender.py` 실행 환경
+- FastAPI 또는 Express.js (Python 호출용)
+
+---
+
+## 🔄 마이그레이션 전략
+
+### Mock → Real DB
+현재는 Mock 데이터로 개발하되, 향후 Real DB 연동 시:
+1. API 엔드포인트만 교체
+2. 프론트엔드 코드는 변경 없음
+3. TypeScript 인터페이스 유지
+
+### AI 추천 학습 데이터 확장
+- 초기: `safety_master.db` 기존 데이터 활용
+- 중기: 사용자 선택 패턴 수집 → 재학습
+- 장기: GPT API 연동 고려
+
+---
+
+## 📊 성공 지표
+
+### 사용성 개선
+- ✅ 소분류 검색 시 0.5초 이내 반응
+- ✅ 페이지네이션으로 모달 로딩 속도 50% 향상
+- ✅ AI 추천 상위 3개 중 1개 이상 선택률 30%+
+
+### 코드 품질
+- ✅ TypeScript strict 모드 에러 없음
+- ✅ 재사용 가능한 컴포넌트 구조
+- ✅ 디자인 시스템 일관성 유지
+
+---
+
+## 🎯 실행 계획
+
+### Step 1: 소분류 검색 (1-2시간)
+1. `SubcategoryCheckList.tsx` 수정
+2. 검색창 UI 추가
+3. 필터링 로직 구현
+4. 브라우저 테스트
+
+### Step 2: 위험요인 페이지네이션 (2-3시간)
+1. `RiskFactorSelector.tsx` 수정
+2. 페이지네이션 상태 관리 추가
+3. 이전/다음 버튼 UI 구현
+4. 검색 연동 (검색 시 페이지 1로)
+5. 브라우저 테스트
+
+### Step 3: AI 추천 Mock 데이터 생성 (30분)
+1. `apps/admin-web/src/mocks/ai-recommendations.ts` 생성
+2. Mock 데이터 구조 정의 (AIRecommendation 인터페이스)
+3. 여러 카테고리/소분류 조합에 대한 예시 데이터 작성
+4. `getAIRecommendations()` 함수 구현
+
+### Step 4: AI 추천 UI 통합 (1.5시간)
+1. API 호출 로직 추가
+2. AI 추천 UI 섹션 구현
+3. 로딩 상태 처리
+4. 에러 처리
+5. 브라우저 테스트
+
+### Step 5: 통합 테스트 (1시간)
+1. 전체 플로우 테스트
+2. 엣지 케이스 확인
+3. 성능 측정
+4. 버그 수정
+
+### Step 6: 커밋 및 문서화 (30분)
+1. Git 커밋 (의미 있는 단위로)
+2. 체인지로그 작성
+3. README 업데이트
+
+---
+
+## 📝 변경 로그 (작업 후 작성)
+
+- [ ] 소분류 검색 기능 추가
+- [ ] 위험요인 모달 페이지네이션 구현
+- [ ] AI 추천 Mock 데이터 생성
+- [ ] AI 추천 UI 통합 (Mock 데이터 기반)
+- [ ] 디자인 일관성 검토
+- [ ] 테스트 완료
+
+## 🔮 향후 작업 (다른 개발자)
+
+- [ ] Python `recommender.py` 호출 백엔드 API 구현
+- [ ] SQLite DB `safety_master.db` 연동
+- [ ] 실제 스코어링 알고리즘 적용
+- [ ] 프론트엔드 Mock → Real API 교체
+- [ ] 성능 최적화 (캐싱, 인덱싱)
+- [ ] 사용자 선택 패턴 학습 기능
+
+---
+
+**작성자**: Prometheus (Planning Agent)
+**승인 대기**: 사용자 확인 후 Sisyphus 실행
+**백엔드 연동**: 추후 다른 개발자가 진행

--- a/.sisyphus/logs/2026-01-26-risk-assessment-font-size-increase.md
+++ b/.sisyphus/logs/2026-01-26-risk-assessment-font-size-increase.md
@@ -1,0 +1,152 @@
+# 위험성평가 페이지 글자 크기 125% 증가
+
+**작업일**: 2026-01-26
+**브랜치**: feature/14-risk-assessment-ui-improvements
+**작업자**: Claude Code
+
+## 작업 개요
+
+위험성평가 관련 페이지들(목록, 만들기, 상세보기)의 글자 크기를 125% 기준으로 재설정하여 가독성을 개선했습니다.
+
+## 변경된 파일
+
+### 페이지 파일
+1. **RiskAssessmentPage.tsx** - 위험성평가 목록 페이지
+2. **CreateAssessmentPage.tsx** - 위험성평가 만들기 페이지
+3. **LegacyInitialAssessmentPage.tsx** - 최초 위험성평가 만들기 페이지
+4. **RiskAssessmentDetailPage.tsx** - 위험성평가 상세보기 페이지
+
+### 컴포넌트 파일
+5. **BasicInfoSection.tsx** - 기본 정보 섹션 컴포넌트
+6. **RiskFactorCard.tsx** - 위험 요인 카드 컴포넌트
+
+## 글자 크기 변경 매핑
+
+Tailwind CSS의 제한된 크기 옵션 내에서 125%에 가장 근접한 크기로 조정:
+
+| 기존 크기 | 새 크기 | 증가율 | 적용 대상 |
+|-----------|---------|--------|-----------|
+| `text-xs` (12px) | `text-sm` (14px) | 약 117% | 상태 배지, 작은 텍스트 |
+| `text-sm` (14px) | `text-base` (16px) | 약 114% | 라벨, 입력 필드, 버튼, 본문 |
+| `text-base` (16px) | `text-lg` (18px) | 약 112% | 일반 텍스트 |
+| `text-lg` (18px) | `text-xl` (20px) | 약 111% | 섹션 제목 (h2, h3) |
+| `text-xl` (20px) | `text-2xl` (24px) | 120% | 페이지 제목 (h1) |
+
+## 상세 변경 내역
+
+### 1. RiskAssessmentPage.tsx (목록 페이지)
+
+- **페이지 제목**: `text-xl` → `text-2xl`
+- **설명 텍스트**: `text-sm` → `text-base`
+- **필터 라벨**: `text-sm` → `text-base`
+- **필터 버튼**: `text-sm` → `text-base`
+- **테이블 헤더**: `text-xs` → `text-sm`
+- **테이블 셀**: `text-sm` → `text-base`
+- **상태 배지**: `text-xs` → `text-sm`
+- **빈 상태 메시지**: `text-sm` → `text-base`
+- **페이지네이션 버튼**: `text-sm` → `text-base`, 버튼 크기 `w-8 h-8` → `w-10 h-10`
+
+### 2. CreateAssessmentPage.tsx (만들기 페이지)
+
+- **페이지 제목**: `text-xl` → `text-2xl`
+- **성공 메시지**: 기본 크기 → `text-base`
+- **에러 메시지**: 기본 크기 → `text-base`
+- **로딩 메시지**: 기본 크기 → `text-lg`
+- **안내 텍스트**: 기본 크기 → `text-base`
+
+### 3. LegacyInitialAssessmentPage.tsx (최초 평가 만들기)
+
+- **페이지 제목**: `text-xl` → `text-2xl`
+- 하위 컴포넌트들의 텍스트 크기는 각 컴포넌트에서 조정
+
+### 4. RiskAssessmentDetailPage.tsx (상세보기 페이지)
+
+- **페이지 제목 (h1)**: `text-xl` → `text-2xl`
+- **섹션 제목 (h2)**: `text-lg` → `text-xl`
+- **설명 텍스트**: `text-sm` → `text-base`
+- **라벨**: `text-sm` → `text-base`
+- **입력 필드**: `text-sm` → `text-base`
+- **상태 배지**: `text-xs` → `text-sm`
+- **버튼 텍스트**: `text-sm` → `text-base`
+- **서명 박스 텍스트**: `text-sm` → `text-base`
+- **서명 필요 텍스트**: `text-xs` → `text-sm`
+- **서명 불러오기 버튼**: `text-xs` → `text-sm`
+
+### 5. BasicInfoSection.tsx (기본 정보 컴포넌트)
+
+- **섹션 제목**: `text-lg` → `text-xl`
+- **라벨**: `text-sm` → `text-base`
+- **텍스트**: `text-sm` → `text-base`
+- **버튼**: `text-sm` → `text-base`
+- **입력 필드**: `text-sm` → `text-base`
+
+### 6. RiskFactorCard.tsx (위험 요인 카드)
+
+- **라벨**: `text-sm` → `text-base`
+- **삭제 버튼**: `text-sm` → `text-base`
+- **입력 필드**: `text-sm` → `text-base`
+- **라디오 버튼 라벨**: `text-sm` → `text-base`
+
+## 영향 범위
+
+### 페이지별 영향
+- **목록 페이지**: 테이블, 필터, 페이지네이션 모든 텍스트 확대
+- **만들기 페이지**: 제목, 메시지, 폼 컴포넌트 텍스트 확대
+- **상세보기 페이지**: 전체 콘텐츠 영역 텍스트 확대
+
+### 사용자 경험 개선
+- 가독성 향상으로 피로도 감소
+- 중요 정보(제목, 라벨, 상태)의 시인성 증가
+- 입력 필드의 가시성 개선으로 오입력 방지
+
+## 호환성 확인
+
+- ✅ 기존 레이아웃 유지 (여백, 패딩 변경 없음)
+- ✅ 반응형 디자인 유지
+- ✅ 컴포넌트 재사용성 유지
+- ✅ 디자인 시스템 일관성 유지
+
+## 테스트 확인사항
+
+- [x] 목록 페이지 텍스트 크기 확대 확인
+- [x] 만들기 페이지 텍스트 크기 확대 확인
+- [x] 상세보기 페이지 텍스트 크기 확대 확인
+- [x] 컴포넌트 재사용 시 텍스트 크기 일관성 확인
+- [x] HMR (Hot Module Replacement) 정상 작동
+
+## 후속 작업 제안
+
+1. 다른 페이지들도 동일한 기준으로 글자 크기 조정 검토
+2. 모바일 반응형에서의 글자 크기 추가 조정 필요 시 반영
+3. 사용자 피드백 수집 후 미세 조정
+
+## 기술적 고려사항
+
+### Tailwind CSS 크기 단계
+Tailwind CSS는 고정된 크기 단계를 제공하므로 정확히 125% 증가는 불가능합니다.
+가장 근접한 단계로 조정하여 일관성을 유지했습니다:
+
+- 12px → 14px (약 117%)
+- 14px → 16px (약 114%)
+- 16px → 18px (약 112%)
+- 18px → 20px (약 111%)
+- 20px → 24px (120%)
+
+평균적으로 약 115% 증가하여 125% 목표에 근접합니다.
+
+### 패턴 기반 일괄 변경
+`replace_all: true` 옵션을 사용하여 동일한 패턴을 일괄 변경했습니다:
+- 효율성: 파일당 여러 변경사항을 한 번에 처리
+- 일관성: 동일한 용도의 텍스트는 동일한 크기로 변경
+- 안정성: 수동 수정으로 인한 실수 방지
+
+---
+
+**작업 완료**: 2026-01-26 오후
+**커밋 대상 파일**:
+- apps/admin-web/src/pages/RiskAssessmentPage.tsx
+- apps/admin-web/src/pages/risk-assessment/CreateAssessmentPage.tsx
+- apps/admin-web/src/pages/risk-assessment/LegacyInitialAssessmentPage.tsx
+- apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx
+- apps/admin-web/src/pages/risk-assessment/components/BasicInfoSection.tsx
+- apps/admin-web/src/pages/risk-assessment/components/RiskFactorCard.tsx

--- a/.sisyphus/logs/2026-01-26-risk-assessment-table-cleanup.md
+++ b/.sisyphus/logs/2026-01-26-risk-assessment-table-cleanup.md
@@ -1,0 +1,274 @@
+# 위험성평가 테이블 정리 및 UI 개선
+
+**작업일**: 2026-01-26
+**브랜치**: feature/12-risk-assessment-approval-line
+**작업자**: Claude Code
+
+## 작업 개요
+
+위험성평가 목록 테이블과 상세보기 화면의 UI를 정리하여 사용자 혼란을 제거하고 명확한 정보 구조를 제공합니다.
+
+## 주요 변경사항
+
+### 1. 목록 테이블 "결재사항" 컬럼 제거
+
+**파일**: `apps/admin-web/src/pages/RiskAssessmentPage.tsx`
+
+#### 문제점
+"결재사항" 컬럼이 서로 다른 성격의 데이터를 혼재:
+- **결재라인 서명 상태** (정적 데이터, 문서 승인)
+- **근로자 문서 확인 현황** (동적 데이터, 매일 변화)
+- **평가 유형별 의미 차이**:
+  - 최초/정기: 작업기간 중 1회 확인
+  - 수시/상시: 매일 TBM 진행 여부
+
+#### 해결 방안
+- 목록 테이블에서 "결재사항" 컬럼 **완전 제거**
+- Phase 2에서 타입별 특화 기능 개발 시 재설계
+- 근로자 확인 기능은 상세보기 내 별도 탭으로 구현 예정
+
+#### 변경 내용
+
+**테이블 헤더** (7개 → 6개 컬럼)
+```tsx
+// 변경 전
+<th>소속</th>
+<th>작업기간</th>
+<th>작업공종(대분류)</th>
+<th>작성자</th>
+<th>구분</th>
+<th>결재상태</th>
+<th>결재사항</th>  // ← 제거
+
+// 변경 후
+<th>소속</th>
+<th>작업기간</th>
+<th>작업공종(대분류)</th>
+<th>작성자</th>
+<th>구분</th>
+<th>결재상태</th>
+```
+
+**테이블 바디**
+```tsx
+// 제거된 셀
+<td className="px-4 py-4 text-base text-slate-600">
+  {assessment.workerCount}명 결재
+  {assessment.unconfirmedCount && assessment.unconfirmedCount > 0 && (
+    <span className="text-red-600 font-medium ml-2">
+      (미확인 {assessment.unconfirmedCount}명)
+    </span>
+  )}
+</td>
+```
+
+#### 유지된 데이터
+- `workerCount`, `unconfirmedCount` 필드는 interface와 Mock 데이터에 유지
+- Phase 2에서 근로자 확인 기능 구현 시 재사용 예정
+
+---
+
+### 2. 상세보기 문서번호 제거
+
+**파일**: `apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx`
+
+#### 변경 이유
+- 시스템 내부 ID가 사용자에게 노출됨
+- 사용자에게 불필요한 정보
+
+#### 변경 내용
+
+**상세보기 헤더**
+```tsx
+// 변경 전
+<div>
+  <h1 className="text-2xl font-black tracking-tight text-slate-800">위험성평가 상세</h1>
+  <p className="text-base text-slate-500 mt-1">문서 번호: {documentId}</p>
+</div>
+
+// 변경 후
+<div>
+  <h1 className="text-2xl font-black tracking-tight text-slate-800">위험성평가 상세</h1>
+</div>
+```
+
+#### 유지된 로직
+- `documentId` 변수 및 관련 로직은 **모두 유지**
+- 서버 API 호출, 라우팅, localStorage 키 등에 계속 사용
+- UI에만 표시하지 않음
+
+---
+
+### 3. DRAFT 상태 제거 (이전 작업)
+
+**파일**: `apps/admin-web/src/pages/risk-assessment/CreateAssessmentPage.tsx`
+
+#### 변경 내용
+```tsx
+// 변경 전
+status: 'DRAFT',  // 작성중 상태, localStorage 전용
+
+// 변경 후
+status: 'PENDING',  // 바로 결재대기 상태로 생성
+```
+
+#### 변경 사유
+- DRAFT 개념이 명확히 정의되지 않음
+- 만들기 후 바로 확인 및 수정 가능하도록 개선
+- 임시 저장 대신 즉시 서버 전송 방식 채택
+
+---
+
+### 4. 접근 제한 및 오류 메시지 개선 (이전 작업)
+
+**파일**: `apps/admin-web/src/pages/RiskAssessmentPage.tsx`
+
+#### 클릭 이벤트 로직
+```tsx
+onClick={() => {
+  // 최초 위험성평가는 모두 열람 가능
+  if (assessment.type === 'INITIAL') {
+    navigate(`/safety/risk/${assessment.id}`);
+    return;
+  }
+
+  // 수시/정기/상시는 개발중
+  alert('해당 유형의 위험성평가는 현재 개발중입니다.\n최초 위험성평가만 상세보기가 가능합니다.');
+}}
+```
+
+#### 개선 사항
+- DRAFT 상태 체크 제거
+- 최초 평가는 작업기간 상태와 무관하게 모두 열람 가능
+- 명확한 오류 메시지 제공
+
+---
+
+## 최종 UI 구조
+
+### 목록 테이블
+```
+┌─────┬──────────┬──────────────┬────────┬────────────┬──────────┐
+│ 소속 │ 작업기간 │ 작업공종(대분류) │ 작성자 │    구분    │ 결재상태 │
+├─────┼──────────┼──────────────┼────────┼────────────┼──────────┤
+│ 전체 │ 26-01-20 │   전체 공종   │ 김안전 │ 작업기간 중 │ 결재완료 │
+│      │  ~       │              │        │            │          │
+│      │ 26-02-20 │              │        │            │          │
+└─────┴──────────┴──────────────┴────────┴────────────┴──────────┘
+```
+
+### 상세보기 헤더
+```
+← [뒤로가기]
+위험성평가 상세
+
+[목록] [수정] [삭제]
+```
+
+---
+
+## 데이터 구조 유지 사항
+
+### RiskAssessment Interface
+```typescript
+interface RiskAssessment {
+  id: string;
+  type: AssessmentType;
+  title: string;
+  status: AssessmentStatus;
+  workPeriodStart: string;
+  workPeriodEnd: string;
+  workCategory: string;
+  author: string;
+  teamId?: string;
+  createdAt: string;
+  workerCount?: number;        // 유지 (Phase 2 재사용)
+  unconfirmedCount?: number;   // 유지 (Phase 2 재사용)
+}
+```
+
+### Mock 데이터
+- 모든 평가 항목에 `workerCount`, `unconfirmedCount` 값 유지
+- 추후 근로자 확인 기능 구현 시 즉시 활용 가능
+
+---
+
+## 향후 계획 (Phase 2)
+
+### 근로자 문서 확인 기능
+- **위치**: 상세보기 내 별도 탭
+- **최초/정기**: 작업기간 중 확인한 근로자 명단 관리
+- **수시/상시**: TBM 진행 여부 및 참석자 관리
+
+### TBM (Tool Box Meeting) 기능
+- 상시 위험성평가와 연동
+- 매일 진행 여부 체크
+- TBM 문서 생성 및 이력 관리
+
+### 데이터 활용
+- 현재 유지 중인 `workerCount`, `unconfirmedCount` 필드 사용
+- 백엔드 API 연동 시 즉시 활용
+
+---
+
+## 기술적 고려사항
+
+### 타입 안전성
+- TypeScript interface에서 선택적 필드(`?`)로 정의
+- 하위 호환성 유지
+
+### 컴포넌트 최적화
+- 불필요한 렌더링 제거
+- 테이블 컬럼 수 감소로 성능 개선
+
+### 확장성
+- 데이터 구조는 유지하면서 UI만 변경
+- Phase 2 개발 시 최소한의 수정으로 기능 추가 가능
+
+---
+
+## 테스트 확인사항
+
+### UI 검증
+- [x] 목록 테이블 6개 컬럼 표시
+- [x] 테이블 레이아웃 깔끔하게 정렬
+- [x] 상세보기에서 문서번호 미표시
+- [x] 상세보기 헤더 "위험성평가 상세"만 표시
+
+### 기능 검증
+- [x] 목록에서 최초 평가 클릭 시 정상 이동
+- [x] 상세보기 페이지 로딩 정상
+- [x] 상세보기 모든 데이터 정상 표시
+- [x] 수시/정기/상시 클릭 시 "개발중" alert 표시
+
+### 데이터 검증
+- [x] Mock 데이터 구조 변경 없음
+- [x] workerCount, unconfirmedCount 필드 유지
+- [x] documentId 변수 및 로직 유지
+- [x] localStorage 저장 로직 정상
+
+---
+
+## 커밋 범위
+
+### 수정된 파일
+1. `apps/admin-web/src/pages/RiskAssessmentPage.tsx`
+   - 테이블 헤더: "결재사항" 컬럼 제거
+   - 테이블 바디: 결재사항 셀 제거
+   - 접근 제한 로직 개선
+   - DRAFT 상태 제거
+
+2. `apps/admin-web/src/pages/risk-assessment/CreateAssessmentPage.tsx`
+   - DRAFT → PENDING 상태로 변경
+   - 생성 ID 접두사: draft → doc
+
+3. `apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx`
+   - 문서번호 표시 제거
+
+### 새로 생성된 파일
+- `.sisyphus/plans/risk-assessment-table-cleanup.md` (작업 계획서)
+
+---
+
+**작업 완료**: 2026-01-26
+**다음 단계**: develop 브랜치로 PR 생성

--- a/.sisyphus/logs/2026-01-26-risk-assessment-team-selection.md
+++ b/.sisyphus/logs/2026-01-26-risk-assessment-team-selection.md
@@ -1,0 +1,264 @@
+# 위험성평가 소속 항목 팀 선택 기능 추가
+
+**작업일**: 2026-01-26
+**브랜치**: feature/14-risk-assessment-ui-improvements
+**작업자**: Claude Code
+
+## 작업 개요
+
+위험성평가 최초 만들기와 상세보기 페이지에서 "소속회사" 항목을 "소속"으로 변경하고,
+회사는 고정으로 표시하며 팀(업체)을 드롭다운으로 선택할 수 있는 기능을 추가했습니다.
+
+## 주요 변경사항
+
+### 1. 팀(업체) Mock 데이터 생성
+
+**파일**: `apps/admin-web/src/mocks/teams.ts` (신규)
+
+#### 데이터 구조
+```typescript
+interface Team {
+  id: string;
+  name: string;
+  companyId: string;
+  siteId?: string;
+  type: 'CONTRACTOR' | 'SUBCONTRACTOR' | 'PARTNER';
+  contactPerson?: string;
+  contactPhone?: string;
+  businessNumber?: string;
+  isActive: boolean;
+}
+```
+
+#### Mock 팀 목록
+- **(주)정이앤지** - 원도급사
+- **협력업체A** - 하도급사
+- **협력업체B** - 하도급사
+- **(주)대한건설** - 협력업체
+- **한국안전산업** - 협력업체
+- **비활성업체** - 비활성 상태 (목록에 표시 안 됨)
+
+#### 유틸 함수
+- `getActiveTeams()` - 활성화된 팀 목록 반환
+- `getTeamById(id)` - ID로 팀 찾기
+- `getTeamsByCompanyId(companyId)` - 회사별 팀 목록
+- `getTeamsBySiteId(siteId)` - 현장별 팀 목록
+
+### 2. BasicInfoSection 컴포넌트 수정
+
+**파일**: `apps/admin-web/src/pages/risk-assessment/components/BasicInfoSection.tsx`
+
+#### Props 변경사항
+
+**제거된 Props**
+- `teamName?: string` - 기존 업체명 표시용
+
+**추가된 Props**
+```typescript
+interface Team {
+  id: string;
+  name: string;
+}
+
+interface BasicInfoSectionProps {
+  // ... 기존 props
+  teamId?: string;              // 선택된 팀 ID
+  teams?: Team[];               // 팀 목록
+  onTeamChange?: (teamId: string) => void;  // 팀 변경 핸들러
+  canChangeTeam?: boolean;      // 팀 변경 가능 여부
+}
+```
+
+#### UI 변경사항
+
+**Before (기존)**
+```
+현장명: 통사통사현장
+업체: (주)정이앤지
+소속 회사: (주)통하는사람들
+```
+
+**After (변경 후)**
+```
+현장명: 통사통사현장
+소속:
+  회사: (주)통하는사람들
+  팀(업체): [드롭다운 선택] ▼
+    - 전체 (팀 미지정)
+    - (주)정이앤지
+    - 협력업체A
+    - 협력업체B
+    - (주)대한건설
+    - 한국안전산업
+```
+
+#### 팀 선택 드롭다운 구현
+```tsx
+<select
+  value={teamId || 'all'}
+  onChange={(e) => onTeamChange(e.target.value)}
+  className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-base
+             focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500
+             appearance-none bg-white"
+>
+  <option value="all">전체 (팀 미지정)</option>
+  {teams.map((team) => (
+    <option key={team.id} value={team.id}>
+      {team.name}
+    </option>
+  ))}
+</select>
+```
+
+#### 표시 로직
+- **편집 가능 모드** (`canChangeTeam && onTeamChange`): 드롭다운 표시
+- **읽기 전용 모드**: 선택된 팀명 또는 "전체 (팀 미지정)" 텍스트 표시
+
+### 3. LegacyInitialAssessmentPage 수정
+
+**파일**: `apps/admin-web/src/pages/risk-assessment/LegacyInitialAssessmentPage.tsx`
+
+#### 추가된 기능
+1. **Import 추가**
+   ```typescript
+   import { getActiveTeams } from '@/mocks/teams';
+   ```
+
+2. **State 추가**
+   ```typescript
+   const [teamId, setTeamId] = useState<string>('all');
+   const teams = useMemo(() => getActiveTeams(), []);
+   ```
+
+3. **BasicInfoSection Props 추가**
+   ```typescript
+   <BasicInfoSection
+     // ... 기존 props
+     teamId={teamId}
+     teams={teams}
+     onTeamChange={setTeamId}
+   />
+   ```
+
+### 4. RiskAssessmentDetailPage 수정
+
+**파일**: `apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx`
+
+#### 추가된 기능
+1. **Import 추가**
+   ```typescript
+   import { getActiveTeams } from '@/mocks/teams';
+   ```
+
+2. **State 추가**
+   ```typescript
+   const [teamId, setTeamId] = useState<string>('all');
+   const teams = useMemo(() => getActiveTeams(), []);
+   ```
+
+3. **BasicInfoSection Props 변경**
+   - `teamName` prop 제거
+   - `teamId`, `teams`, `onTeamChange`, `canChangeTeam` props 추가
+   ```typescript
+   <BasicInfoSection
+     // ... 기존 props
+     teamId={teamId}
+     teams={teams}
+     onTeamChange={setTeamId}
+     canChangeTeam={canEdit}
+   />
+   ```
+
+## 기능 설명
+
+### 팀 선택 동작
+
+1. **기본값**: "전체 (팀 미지정)" - `teamId = 'all'`
+2. **특정 팀 선택**: 드롭다운에서 팀 선택 시 해당 팀 ID로 변경
+3. **문서 범위**:
+   - `teamId = 'all'`: 회사 전체 문서
+   - `teamId = 특정 ID`: 해당 팀의 문서
+
+### 권한 제어
+
+- **만들기 페이지**: 항상 팀 선택 가능 (`canChangeTeam` 미지정 시 기본값 true)
+- **상세보기 페이지**: 편집 모드일 때만 팀 선택 가능 (`canChangeTeam={canEdit}`)
+- **읽기 전용**: 드롭다운 대신 선택된 팀명 텍스트로 표시
+
+### 데이터 저장
+
+현재는 컴포넌트 state로만 관리하며, 실제 저장 시 다음 필드가 포함됩니다:
+- `teamId`: 선택된 팀 ID 또는 'all'
+- `teamName`: 선택된 팀명 (참조용)
+
+## UI/UX 개선사항
+
+### 시각적 개선
+- **레이블 변경**: "소속 회사" → "소속"
+- **계층 구조**: 회사(고정) + 팀(선택) 2단 구조로 명확화
+- **드롭다운 스타일**: 오렌지 테마 적용, ChevronDown 아이콘 추가
+
+### 사용성 개선
+- **명확한 기본값**: "전체 (팀 미지정)" 옵션으로 의도 명확화
+- **일관된 표시**: 편집/읽기 모드 모두 동일한 구조 유지
+- **접근성**: 키보드 네비게이션 지원 (기본 select 사용)
+
+## 향후 확장 가능성
+
+### 백엔드 연동 시
+1. **API 연동**
+   - `GET /api/teams` - 팀 목록 조회
+   - `GET /api/teams/:id` - 특정 팀 조회
+   - 현장 필터링: `GET /api/teams?siteId={siteId}`
+
+2. **저장 로직**
+   - 위험성평가 생성/수정 시 `team_id` 필드 포함
+   - `team_id = null` 또는 빈 문자열: 회사 전체
+   - `team_id = UUID`: 특정 팀
+
+3. **권한 검증**
+   - 사용자가 해당 팀 접근 권한이 있는지 확인
+   - 팀 관리자는 자신의 팀만 선택 가능
+
+### 추가 기능
+1. **팀 필터링**: 현장별로 팀 목록 필터링
+2. **팀 정보 표시**: 드롭다운에 업체 타입, 연락처 등 추가 정보
+3. **최근 사용 팀**: 최근 선택한 팀을 상단에 표시
+4. **팀 검색**: 팀이 많을 경우 검색 기능 추가
+
+## 테스트 확인사항
+
+- [x] 팀 목업 데이터 정상 로딩
+- [x] 만들기 페이지에서 팀 선택 드롭다운 표시
+- [x] 상세보기 페이지에서 편집 모드일 때 드롭다운 표시
+- [x] 상세보기 페이지에서 읽기 모드일 때 텍스트 표시
+- [x] "전체 (팀 미지정)" 선택 시 정상 동작
+- [x] 특정 팀 선택 시 정상 동작
+- [x] 드롭다운 스타일 일관성 (오렌지 테마)
+- [x] HMR (Hot Module Replacement) 정상 작동
+
+## 기술적 고려사항
+
+### 컴포넌트 설계
+- **Props 기반 제어**: `canChangeTeam`으로 편집/읽기 모드 전환
+- **선택적 Props**: 팀 관련 props를 선택적으로 처리하여 하위 호환성 유지
+- **Memo 최적화**: `useMemo`로 팀 목록 재계산 방지
+
+### 상태 관리
+- **로컬 State**: 현재는 각 페이지에서 독립적으로 관리
+- **기본값 처리**: `teamId = 'all'`을 명시적 기본값으로 사용
+- **동기화**: 향후 URL 파라미터 또는 전역 상태와 동기화 고려
+
+### 접근성
+- **Semantic HTML**: 기본 `<select>` 요소 사용으로 스크린 리더 지원
+- **키보드 네비게이션**: 방향키, Enter, Escape 기본 지원
+- **포커스 관리**: 오렌지 테마 focus ring 적용
+
+---
+
+**작업 완료**: 2026-01-26 오후
+**커밋 대상 파일**:
+- apps/admin-web/src/mocks/teams.ts (신규)
+- apps/admin-web/src/pages/risk-assessment/components/BasicInfoSection.tsx
+- apps/admin-web/src/pages/risk-assessment/LegacyInitialAssessmentPage.tsx
+- apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx

--- a/.sisyphus/logs/2026-01-26-risk-factor-modal-ai-improvements.md
+++ b/.sisyphus/logs/2026-01-26-risk-factor-modal-ai-improvements.md
@@ -1,0 +1,218 @@
+# 위험요인 선택 모달 AI 추천 및 UI 개선
+
+**작업일**: 2026-01-26
+**브랜치**: feature/14-risk-assessment-ui-improvements
+**작업자**: Claude Code
+
+## 작업 개요
+
+최초 위험성평가(Initial Risk Assessment) 기능 개선 Phase 1의 일환으로 위험요인 선택 모달에 AI 추천, 페이지네이션, 검색 기능을 구현하고 레이아웃 오버플로우 문제를 해결했습니다.
+
+## 주요 변경사항
+
+### 1. RiskFactorSelectModal.tsx - AI 추천 기능 구현
+
+**파일**: `apps/admin-web/src/pages/risk-assessment/modals/RiskFactorSelectModal.tsx`
+
+#### 추가된 기능
+
+1. **AI 추천 위험요인 표시**
+   - 선택된 카테고리/소분류에 맞는 AI 추천 위험요인 자동 로딩
+   - 로딩 스피너 애니메이션 (Loader2 아이콘)
+   - 추천 점수 기반 정렬 (0-100점)
+   - 오렌지 그라데이션 카드 디자인
+   - 재해유형, 추천 근거 표시
+
+2. **페이지네이션**
+   - 일반 위험요인 목록을 페이지당 20개씩 분할
+   - 이전/다음 버튼과 현재 페이지 표시
+   - 검색 시 자동으로 1페이지로 리셋
+
+3. **레이아웃 개선**
+   - 스크롤 가능한 콘텐츠 영역 추가 (`flex-1 overflow-y-auto`)
+   - 헤더/탭과 버튼은 고정, 중간 콘텐츠만 스크롤
+   - 모달 높이 `max-h-[80vh]` 내에서 모든 요소가 표시되도록 구조 개선
+
+#### 기술적 구현 세부사항
+
+**상태 관리**
+```typescript
+const [currentPage, setCurrentPage] = useState(1);
+const [aiRecommendations, setAiRecommendations] = useState<AIRecommendation[]>([]);
+const [isLoadingAI, setIsLoadingAI] = useState(false);
+const itemsPerPage = 20;
+```
+
+**AI 추천 로딩 useEffect**
+```typescript
+useEffect(() => {
+  if (isOpen && categoryId !== undefined && subcategoryId !== undefined && !isCustomSubcategory) {
+    loadMockAIRecommendations();
+  } else {
+    setAiRecommendations([]);
+  }
+}, [isOpen, categoryId, subcategoryId, isCustomSubcategory]);
+```
+
+**페이지네이션 계산**
+```typescript
+const totalPages = Math.ceil(filteredFactors.length / itemsPerPage);
+const startIndex = (currentPage - 1) * itemsPerPage;
+const endIndex = startIndex + itemsPerPage;
+const paginatedFactors = filteredFactors.slice(startIndex, endIndex);
+```
+
+**제출 시 AI + 일반 위험요인 통합**
+```typescript
+const aiFactors = aiRecommendations
+  .filter(ai => selectedIds.includes(ai.id))
+  .map(ai => ({ factor: ai.riskFactor, improvement: ai.improvement }));
+
+const regularFactors = mockFactors
+  .filter(f => selectedIds.includes(f.id))
+  .map(f => ({ factor: f.factor, improvement: f.improvement }));
+
+result = [...aiFactors, ...regularFactors];
+```
+
+### 2. ai-recommendations.ts - Mock 데이터 확장
+
+**파일**: `apps/admin-web/src/mocks/ai-recommendations.ts`
+
+카테고리 3(제조업) 소분류 101~105에 대한 AI 추천 데이터 추가:
+- `'3-101'`: 6개 추천 위험요인
+- `'3-102'`: 4개 추천 위험요인
+- `'3-103'`: 4개 추천 위험요인
+- `'3-104'`: 3개 추천 위험요인
+- `'3-105'`: 3개 추천 위험요인
+
+**데이터 구조 예시**
+```typescript
+'3-101': [
+  {
+    id: 9061,
+    taskName: '가설전선 설치작업',
+    riskFactor: '안전대를 사용하지 않고 고소부위 작업중 추락',
+    accidentType: '떨어짐',
+    score: 90,
+    reason: "작업명 '가설전선' 매칭(40) + 고위험 '떨어짐'(30) + 복합매칭(20)",
+    improvement: '고소부위 작업시 안전대 고리 체결 철저'
+  },
+  // ...
+]
+```
+
+### 3. AdHocAssessmentForm.tsx - 기존 변경사항 유지
+
+**파일**: `apps/admin-web/src/components/risk-assessment/forms/AdHocAssessmentForm.tsx`
+
+수시 위험성평가 폼의 기존 개선사항 유지 (이전 커밋에서 변경됨)
+
+## UI/UX 개선사항
+
+### 모달 레이아웃 구조
+```
+┌─────────────────────────────┐
+│ 헤더 + 닫기 버튼             │ ← 고정
+│ 제목: 위험요인 선택          │
+│ 탭: [목록 선택] [직접 입력]  │
+├─────────────────────────────┤
+│ ╔═══════════════════════╗  │
+│ ║ 🔍 검색바              ║  │
+│ ║                       ║  │
+│ ║ 🤖 AI 추천 위험요인    ║  │
+│ ║ • 점수 배지           ║  │ ← 스크롤 가능
+│ ║ • 오렌지 그라데이션   ║  │   영역
+│ ║ • 재해유형 표시       ║  │
+│ ║                       ║  │
+│ ║ 📋 일반 위험요인      ║  │
+│ ║ • 20개씩 페이징       ║  │
+│ ║ • 체크박스 선택       ║  │
+│ ║                       ║  │
+│ ║ ◀ 이전 1/5 다음 ▶    ║  │
+│ ╚═══════════════════════╝  │
+├─────────────────────────────┤
+│ N개 선택됨   [취소] [선택완료] │ ← 고정
+└─────────────────────────────┘
+```
+
+### 디자인 시스템 준수
+
+**AI 추천 카드**
+- 배경: `bg-gradient-to-r from-orange-50 to-white`
+- 테두리: `border-2 border-orange-100` → 호버 시 `border-orange-300`
+- 점수 배지: `bg-orange-100 text-orange-600`
+- 체크박스: `text-orange-500 focus:ring-orange-500`
+
+**일반 위험요인 목록**
+- 배경: `bg-white` → 호버 시 `bg-orange-50`
+- 테두리: `border-gray-200`
+- 체크박스: `text-orange-500`
+
+**페이지네이션 버튼**
+- 기본: `border border-gray-300 hover:bg-gray-50`
+- 비활성: `disabled:opacity-50 disabled:cursor-not-allowed`
+
+## 해결된 이슈
+
+### 1. Mock 데이터 부족 문제
+**증상**: 카테고리 3 선택 시 AI 추천 결과 0개
+**원인**: `ai-recommendations.ts`에 카테고리 1, 2만 존재
+**해결**: 카테고리 3 소분류 101~105 데이터 추가
+
+### 2. Falsy 값 처리 문제
+**증상**: categoryId 또는 subcategoryId가 0일 때 useEffect 미실행
+**원인**: `if (categoryId && subcategoryId)` 조건이 0을 falsy로 간주
+**해결**: `if (categoryId !== undefined && subcategoryId !== undefined)` 로 변경
+
+### 3. 모달 콘텐츠 오버플로우
+**증상**: AI 추천 + 일반 목록이 길어지면 모달 밖으로 넘침, 버튼이 화면 밖으로 사라짐
+**원인**: 고정 높이 없이 콘텐츠가 무한정 늘어남
+**해결**:
+- 모달 컨테이너: `max-h-[80vh] flex flex-col`
+- 콘텐츠 영역: `flex-1 overflow-y-auto` (스크롤 가능)
+- 헤더/버튼: 고정 위치 유지
+
+### 4. JSX 구조 에러 방지
+**문제**: 여러 번 시도했던 `<div>` 래퍼 추가 시 JSX 닫기 태그 오류 발생
+**해결**: 한 번에 전체 구조를 정확히 파악하여 올바른 위치에 래퍼 추가
+
+## 테스트 확인사항
+
+- [x] AI 추천 로딩 스피너 표시
+- [x] 카테고리 3 소분류 101~105 선택 시 AI 추천 정상 표시
+- [x] AI 추천 + 일반 위험요인 중복 선택 가능
+- [x] 페이지네이션 정상 동작 (20개씩, 이전/다음)
+- [x] 검색 시 페이지 1로 리셋
+- [x] 모달 스크롤 정상 동작, 버튼 항상 보임
+- [x] 선택 완료 시 AI + 일반 위험요인 모두 제출
+- [x] HMR (Hot Module Replacement) 정상 작동
+
+## 향후 작업
+
+Phase 1 완료 후 예정:
+- [ ] 실제 백엔드 API 연동 (Mock 데이터 대체)
+- [ ] AI 추천 알고리즘 고도화
+- [ ] 중복 위험요인 자동 필터링
+- [ ] 즐겨찾기/최근 사용 위험요인 기능
+
+## 참고사항
+
+### 콘솔 로그
+디버깅을 위해 AI 추천 로딩 시 콘솔 로그 출력:
+```
+🔍 AI 추천 요청: {categoryId: 3, subcategoryId: 101, key: '3-101'}
+📊 AI 추천 결과: 6 개 [...]
+```
+
+### 성능 고려사항
+- Mock 데이터 로딩에 800ms 딜레이 추가 (실제 API 응답 시간 시뮬레이션)
+- 페이지네이션으로 렌더링 성능 최적화 (한 번에 최대 20개만 렌더)
+- AI 추천 ID는 9000번대, 일반 위험요인 ID는 1~1000번대로 분리
+
+---
+
+**작업 완료**: 2026-01-26 11:43
+**커밋 대상 파일**:
+- `apps/admin-web/src/pages/risk-assessment/modals/RiskFactorSelectModal.tsx`
+- `apps/admin-web/src/mocks/ai-recommendations.ts`

--- a/.sisyphus/plans/risk-assessment-table-cleanup.md
+++ b/.sisyphus/plans/risk-assessment-table-cleanup.md
@@ -1,0 +1,317 @@
+# 위험성평가 테이블 정리 작업 계획
+
+**작성일**: 2026-01-26
+**계획자**: Prometheus
+**우선순위**: Medium
+**예상 난이도**: Low
+
+---
+
+## 📋 작업 개요
+
+위험성평가 목록 테이블과 상세보기 화면의 UI를 정리합니다.
+
+### 배경
+- **문제점 1**: 목록 테이블의 "결재사항" 컬럼이 서로 다른 성격의 데이터 혼재
+  - 결재라인 서명 상태 (정적 데이터)
+  - 근로자 문서 확인 현황 (동적 데이터)
+  - 평가 유형별로 확인 의미가 다름 (최초: 기간 중 1회, 상시: 매일 TBM)
+
+- **문제점 2**: 상세보기에 문서번호가 사용자에게 노출
+  - 시스템 내부 ID가 화면에 표시됨
+  - 사용자에게 불필요한 정보
+
+### 해결 방향
+1. 목록 테이블에서 "결재사항" 컬럼 완전 제거
+2. 상세보기에서 문서번호 UI 제거 (서버 저장 로직은 유지)
+3. 추후 Phase 2에서 타입별 특화 기능 개발 시 재설계
+
+---
+
+## 🎯 작업 목표
+
+### 1차 목표
+- [x] 목록 테이블 "결재사항" 컬럼 제거
+- [x] 상세보기 "문서 번호" 표시 제거
+- [x] 코드 정리 (불필요한 필드는 유지, 나중에 재사용)
+
+### 제외 사항
+- Mock 데이터의 `workerCount`, `unconfirmedCount` 필드는 **유지**
+- 추후 근로자 확인 기능 구현 시 재사용 예정
+
+---
+
+## 📁 영향받는 파일
+
+### 주요 수정 파일
+1. `apps/admin-web/src/pages/RiskAssessmentPage.tsx`
+   - 테이블 헤더: "결재사항" 컬럼 제거
+   - 테이블 바디: 결재사항 셀 제거
+   - 컬럼 수: 7개 → 6개
+
+2. `apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx`
+   - 318번 줄: `<p className="text-base text-slate-500 mt-1">문서 번호: {documentId}</p>` 제거
+
+### 유지되는 데이터 구조
+- `RiskAssessment` interface의 `workerCount`, `unconfirmedCount` 필드
+- Mock 데이터의 해당 값들
+- documentId 변수 및 로직 (서버 통신용)
+
+---
+
+## 🔧 구현 상세
+
+### Task 1: 목록 테이블 헤더 수정
+
+**파일**: `apps/admin-web/src/pages/RiskAssessmentPage.tsx`
+
+**위치**: 테이블 `<thead>` 섹션
+
+**변경 전**:
+```tsx
+<thead className="bg-gray-50 border-b border-gray-200">
+  <tr>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">소속</th>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">작업기간</th>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">작업공종(대분류)</th>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">작성자</th>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">구분</th>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">결재상태</th>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">결재사항</th>
+  </tr>
+</thead>
+```
+
+**변경 후**:
+```tsx
+<thead className="bg-gray-50 border-b border-gray-200">
+  <tr>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">소속</th>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">작업기간</th>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">작업공종(대분류)</th>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">작성자</th>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">구분</th>
+    <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">결재상태</th>
+  </tr>
+</thead>
+```
+
+**작업**: 마지막 `<th>` (결재사항) 제거
+
+---
+
+### Task 2: 목록 테이블 바디 수정
+
+**파일**: `apps/admin-web/src/pages/RiskAssessmentPage.tsx`
+
+**위치**: 테이블 `<tbody>` 섹션, `filteredAssessments.map()` 내부
+
+**변경 전**:
+```tsx
+<tr ...>
+  {/* 소속 */}
+  <td className="px-4 py-4 text-base text-slate-600">{teamName}</td>
+
+  {/* 작업기간 */}
+  <td className="px-4 py-4 text-base text-slate-600">
+    {assessment.workPeriodStart.slice(2)} ~ {assessment.workPeriodEnd.slice(2)}
+  </td>
+
+  {/* 작업공종(대분류) */}
+  <td className="px-4 py-4 text-base text-slate-700 font-medium">
+    {assessment.workCategory}
+  </td>
+
+  {/* 작성자 */}
+  <td className="px-4 py-4 text-base text-slate-600">{assessment.author}</td>
+
+  {/* 구분 (작업기간 상태) */}
+  <td className="px-4 py-4">
+    <span className={`px-2 py-1 text-sm font-medium rounded ...`}>
+      {workPeriodStatus}
+    </span>
+  </td>
+
+  {/* 결재상태 */}
+  <td className="px-4 py-4">
+    <span className={`px-2 py-1 text-sm font-medium rounded ${approvalStatus.color}`}>
+      {approvalStatus.label}
+    </span>
+  </td>
+
+  {/* 결재사항 */}
+  <td className="px-4 py-4 text-base text-slate-600">
+    {assessment.workerCount}명 결재
+    {assessment.unconfirmedCount && assessment.unconfirmedCount > 0 && (
+      <span className="text-red-600 font-medium ml-2">
+        (미확인 {assessment.unconfirmedCount}명)
+      </span>
+    )}
+  </td>
+</tr>
+```
+
+**변경 후**:
+```tsx
+<tr ...>
+  {/* 소속 */}
+  <td className="px-4 py-4 text-base text-slate-600">{teamName}</td>
+
+  {/* 작업기간 */}
+  <td className="px-4 py-4 text-base text-slate-600">
+    {assessment.workPeriodStart.slice(2)} ~ {assessment.workPeriodEnd.slice(2)}
+  </td>
+
+  {/* 작업공종(대분류) */}
+  <td className="px-4 py-4 text-base text-slate-700 font-medium">
+    {assessment.workCategory}
+  </td>
+
+  {/* 작성자 */}
+  <td className="px-4 py-4 text-base text-slate-600">{assessment.author}</td>
+
+  {/* 구분 (작업기간 상태) */}
+  <td className="px-4 py-4">
+    <span className={`px-2 py-1 text-sm font-medium rounded ...`}>
+      {workPeriodStatus}
+    </span>
+  </td>
+
+  {/* 결재상태 */}
+  <td className="px-4 py-4">
+    <span className={`px-2 py-1 text-sm font-medium rounded ${approvalStatus.color}`}>
+      {approvalStatus.label}
+    </span>
+  </td>
+</tr>
+```
+
+**작업**: 마지막 `<td>` (결재사항) 블록 전체 제거
+
+---
+
+### Task 3: 상세보기 문서번호 제거
+
+**파일**: `apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx`
+
+**위치**: 318번 줄, 페이지 헤더 부분
+
+**변경 전**:
+```tsx
+<div>
+  <h1 className="text-2xl font-black tracking-tight text-slate-800">위험성평가 상세</h1>
+  <p className="text-base text-slate-500 mt-1">문서 번호: {documentId}</p>
+</div>
+```
+
+**변경 후**:
+```tsx
+<div>
+  <h1 className="text-2xl font-black tracking-tight text-slate-800">위험성평가 상세</h1>
+</div>
+```
+
+**작업**: `<p>` 태그 한 줄 제거
+
+**중요**: `documentId` 변수와 관련 로직은 **삭제하지 않음**
+- 서버 API 호출 시 필요
+- 내부 데이터 추적용
+- UI에만 표시하지 않음
+
+---
+
+## ✅ 검증 항목
+
+### UI 검증
+- [ ] 목록 테이블이 6개 컬럼으로 표시됨
+- [ ] 테이블 레이아웃이 깔끔하게 정렬됨
+- [ ] 상세보기에서 "문서 번호: ..." 텍스트가 사라짐
+- [ ] 상세보기 헤더가 "위험성평가 상세"만 표시됨
+
+### 기능 검증
+- [ ] 목록에서 최초 평가 클릭 시 정상 이동
+- [ ] 상세보기 페이지 로딩 정상
+- [ ] 상세보기에서 모든 데이터 정상 표시
+- [ ] 수시/정기/상시 클릭 시 "개발중" alert 정상
+
+### 데이터 검증
+- [ ] Mock 데이터 구조 변경 없음
+- [ ] workerCount, unconfirmedCount 필드 유지
+- [ ] documentId 변수 및 로직 유지
+- [ ] localStorage 저장 로직 정상
+
+---
+
+## 📝 구현 순서
+
+1. **RiskAssessmentPage.tsx 수정** (목록 테이블)
+   - 테이블 헤더 수정 (Task 1)
+   - 테이블 바디 수정 (Task 2)
+   - 저장 및 확인
+
+2. **RiskAssessmentDetailPage.tsx 수정** (상세보기)
+   - 문서번호 표시 제거 (Task 3)
+   - 저장 및 확인
+
+3. **브라우저 테스트**
+   - 개발 서버 실행
+   - 목록 화면 확인
+   - 상세보기 화면 확인
+
+4. **완료 확인**
+   - 모든 검증 항목 체크
+   - 사용자 확인 요청
+
+---
+
+## 🔮 향후 계획 (Phase 2)
+
+### 근로자 문서 확인 기능
+- **위치**: 상세보기 내 별도 탭 또는 섹션
+- **최초/정기**: 작업기간 중 확인한 근로자 명단
+- **수시/상시**: TBM 진행 여부 및 참석자 관리
+
+### TBM (Tool Box Meeting) 기능
+- 상시 위험성평가와 연동
+- 매일 진행 여부 체크
+- TBM 문서 생성 기능
+
+### 데이터 재활용
+- 현재 유지 중인 `workerCount`, `unconfirmedCount` 사용
+- 백엔드 API 연동 시 즉시 활용 가능
+
+---
+
+## 📌 주의사항
+
+1. **데이터 필드 유지**
+   - `workerCount`, `unconfirmedCount` 필드는 삭제하지 말 것
+   - 추후 기능 개발 시 재사용 예정
+
+2. **documentId 보존**
+   - UI에서만 숨김
+   - 변수 및 로직은 모두 유지
+   - 서버 통신, 라우팅, localStorage 키 등에 사용 중
+
+3. **Mock 데이터 불변**
+   - MOCK_ASSESSMENTS 배열 변경 없음
+   - 기존 테스트 데이터 유지
+
+4. **타입 정의 유지**
+   - RiskAssessment interface 변경 없음
+   - 선택적 필드(`?`)로 정의되어 있어 문제없음
+
+---
+
+## 🎉 완료 기준
+
+- 목록 테이블: 6개 컬럼 (소속, 작업기간, 작업공종, 작성자, 구분, 결재상태)
+- 상세보기: 문서번호 텍스트 미표시
+- 모든 기능 정상 동작
+- 사용자 승인
+
+---
+
+**작성자**: Prometheus
+**검토자**: (미정)
+**승인자**: 사용자

--- a/apps/admin-web/src/components/risk-assessment/forms/AdHocAssessmentForm.tsx
+++ b/apps/admin-web/src/components/risk-assessment/forms/AdHocAssessmentForm.tsx
@@ -234,6 +234,8 @@ export default function AdHocAssessmentForm({ onSubmit, onCancel }: Props) {
         onRemove={handleRemoveFactor}
         disabled={!formData.category_id}
         error={errors.selected_factors}
+        categoryId={formData.category_id ? Number(formData.category_id) : undefined}
+        subcategoryId={formData.subcategory_id ? Number(formData.subcategory_id) : undefined}
       />
 
       {/* 빈도/강도 평가 */}

--- a/apps/admin-web/src/components/risk-assessment/forms/AdHocAssessmentForm.tsx
+++ b/apps/admin-web/src/components/risk-assessment/forms/AdHocAssessmentForm.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useState } from 'react';
+import { addMonths } from 'date-fns';
 import BasicInfoFieldset from './fieldsets/BasicInfoFieldset';
 import TriggerReasonFieldset from './fieldsets/TriggerReasonFieldset';
 import WorkPeriodFieldset from './fieldsets/WorkPeriodFieldset';
@@ -47,17 +48,20 @@ interface Props {
 }
 
 export default function AdHocAssessmentForm({ onSubmit, onCancel }: Props) {
-  const [formData, setFormData] = useState<AdHocAssessmentData>({
-    title: '',
-    site_id: '',
-    team_id: '',
-    trigger_reason: '',
-    work_start_date: new Date(),
-    work_end_date: new Date(),
-    category_id: '',
-    subcategory_id: '',
-    selected_factors: [],
-    assessments: [],
+  const [formData, setFormData] = useState<AdHocAssessmentData>(() => {
+    const today = new Date();
+    return {
+      title: '',
+      site_id: '',
+      team_id: '',
+      trigger_reason: '',
+      work_start_date: today,
+      work_end_date: addMonths(today, 1),
+      category_id: '',
+      subcategory_id: '',
+      selected_factors: [],
+      assessments: [],
+    };
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});

--- a/apps/admin-web/src/components/risk-assessment/forms/InitialAssessmentForm.tsx
+++ b/apps/admin-web/src/components/risk-assessment/forms/InitialAssessmentForm.tsx
@@ -13,6 +13,7 @@ import ApprovalLineSelectModal from '@/pages/risk-assessment/modals/ApprovalLine
 import SubcategoryAddModal from '@/pages/risk-assessment/modals/SubcategoryAddModal';
 import RiskFactorSelectModal from '@/pages/risk-assessment/modals/RiskFactorSelectModal';
 import { useApprovalLines } from '@/stores/approvalLinesStore';
+import { getActiveTeams } from '@/mocks/teams';
 
 let idCounter = 0;
 const generateId = () => `temp-${Date.now()}-${++idCounter}`;
@@ -78,9 +79,12 @@ export default function InitialAssessmentForm({ type, onSubmit, onCancel }: Prop
 
   const [siteName] = useState('통사통사현장');
   const [companyName] = useState('(주)통하는사람들');
+  const [teamId, setTeamId] = useState<string>('all');
   const [workPeriodStart, setWorkPeriodStart] = useState(today);
   const [workPeriodEnd, setWorkPeriodEnd] = useState(oneMonthLater);
   const [approvalModalOpen, setApprovalModalOpen] = useState(false);
+
+  const teams = useMemo(() => getActiveTeams(), []);
 
   const approvalLines = useApprovalLines();
   const availableApprovalLines = useMemo(() => approvalLines, [approvalLines]);
@@ -342,6 +346,8 @@ export default function InitialAssessmentForm({ type, onSubmit, onCancel }: Prop
         <BasicInfoSection
           siteName={siteName}
           companyName={companyName}
+          teamId={teamId}
+          teams={teams}
           approvalLineName={selectedApprovalLine?.name || null}
           approvalLineCount={selectedApprovalLine?.approvers.length || null}
           approvalLineApprovers={
@@ -359,6 +365,7 @@ export default function InitialAssessmentForm({ type, onSubmit, onCancel }: Prop
             if (field === 'start') setWorkPeriodStart(value);
             else setWorkPeriodEnd(value);
           }}
+          onTeamChange={setTeamId}
         />
 
         <div className="space-y-6">

--- a/apps/admin-web/src/components/risk-assessment/forms/fieldsets/RiskItemsFieldset.tsx
+++ b/apps/admin-web/src/components/risk-assessment/forms/fieldsets/RiskItemsFieldset.tsx
@@ -13,6 +13,8 @@ interface Props {
   onRemove: (factorId: string) => void;
   disabled?: boolean;
   error?: string;
+  categoryId?: number;      // AI 추천용
+  subcategoryId?: number;   // AI 추천용
 }
 
 export default function RiskItemsFieldset({
@@ -22,6 +24,8 @@ export default function RiskItemsFieldset({
   onRemove,
   disabled = false,
   error,
+  categoryId,
+  subcategoryId,
 }: Props) {
   return (
     <div className="p-8 rounded-2xl border border-gray-200 bg-white space-y-6">
@@ -39,6 +43,8 @@ export default function RiskItemsFieldset({
         selectedFactorIds={selectedFactors.map(f => f.id)}
         onAdd={onAdd}
         disabled={disabled}
+        categoryId={categoryId}
+        subcategoryId={subcategoryId}
       />
 
       {selectedFactors.length > 0 && (

--- a/apps/admin-web/src/mocks/ai-recommendations.ts
+++ b/apps/admin-web/src/mocks/ai-recommendations.ts
@@ -267,6 +267,96 @@ export const MOCK_AI_RECOMMENDATIONS: Record<string, AIRecommendation[]> = {
       reason: "작업명 '용접' 매칭(40) + 고위험 '질식'(30)",
       improvement: '환기 설비 가동 및 방독 마스크 착용'
     }
+  ],
+
+  // 대분류 3 - 가설전선 설치작업
+  '3-101': [
+    {
+      id: 9061,
+      taskName: '가설전선 설치작업',
+      riskFactor: '안전대를 사용하지 않고 고소부위 작업중 추락',
+      accidentType: '떨어짐',
+      score: 90,
+      reason: "작업명 '가설전선' 매칭(40) + 고위험 '떨어짐'(30) + 복합매칭(20)",
+      improvement: '고소부위 작업시 안전대 고리 체결 철저'
+    },
+    {
+      id: 9062,
+      taskName: '전선작업',
+      riskFactor: '전선 접촉으로 인한 감전',
+      accidentType: '감전',
+      score: 80,
+      reason: "위험요인 '전선' 매칭(20) + 고위험 '감전'(30) + 복합매칭(30)",
+      improvement: '절연장갑 착용 및 전원 차단 후 작업'
+    },
+    {
+      id: 9063,
+      taskName: '가설전선 설치작업',
+      riskFactor: '불안전한 작업발판으로 인한 추락',
+      accidentType: '떨어짐',
+      score: 75,
+      reason: "작업명 '가설전선' 매칭(40) + 고위험 '떨어짐'(30)",
+      improvement: '안전 작업발판 설치 후 작업 실시'
+    }
+  ],
+
+  // 대분류 3 - 가설전선 점검작업
+  '3-102': [
+    {
+      id: 9071,
+      taskName: '가설전선 점검작업',
+      riskFactor: '점검 중 충전부 접촉으로 인한 감전',
+      accidentType: '감전',
+      score: 95,
+      reason: "작업명 '가설전선 점검' 매칭(40) + 고위험 '감전'(30) + 복합매칭(30)",
+      improvement: '점검 전 전원 차단 및 무전압 확인'
+    },
+    {
+      id: 9072,
+      taskName: '전선 점검',
+      riskFactor: '사다리 작업 중 균형 상실로 추락',
+      accidentType: '떨어짐',
+      score: 85,
+      reason: "위험요인 '전선' 매칭(20) + 고위험 '떨어짐'(30) + 복합매칭(30)",
+      improvement: '사다리 고정 및 보조자 배치'
+    }
+  ],
+
+  // 대분류 3 - 기타 소분류들
+  '3-103': [
+    {
+      id: 9081,
+      taskName: '꽂음 접속기작업',
+      riskFactor: '접속기 결합 불량으로 인한 감전',
+      accidentType: '감전',
+      score: 90,
+      reason: "작업명 '꽂음 접속기' 매칭(40) + 고위험 '감전'(30) + 복합매칭(20)",
+      improvement: '접속 후 결합 상태 확인 철저'
+    }
+  ],
+
+  '3-104': [
+    {
+      id: 9091,
+      taskName: '이동형 릴 전선작업',
+      riskFactor: '전선 피복 손상으로 인한 감전',
+      accidentType: '감전',
+      score: 92,
+      reason: "작업명 '이동형 릴 전선' 매칭(40) + 고위험 '감전'(30) + 복합매칭(30)",
+      improvement: '작업 전 전선 피복 상태 확인'
+    }
+  ],
+
+  '3-105': [
+    {
+      id: 9101,
+      taskName: '전동공구 사용작업',
+      riskFactor: '접지 미설치로 인한 감전',
+      accidentType: '감전',
+      score: 88,
+      reason: "작업명 '전동공구' 매칭(40) + 고위험 '감전'(30) + 복합매칭(20)",
+      improvement: '전동공구 접지 확인 후 사용'
+    }
   ]
 };
 

--- a/apps/admin-web/src/mocks/ai-recommendations.ts
+++ b/apps/admin-web/src/mocks/ai-recommendations.ts
@@ -1,0 +1,318 @@
+/**
+ * AI 위험요인 추천 Mock 데이터
+ *
+ * 실제 백엔드 API 연동 전까지 사용되는 Mock 데이터
+ * 추후 실제 API로 교체 예정
+ */
+
+export interface AIRecommendation {
+  id: number;
+  taskName: string;        // 작업명
+  riskFactor: string;      // 위험요인
+  accidentType: string;    // 재해형태
+  score: number;           // 추천 점수 (0-100)
+  reason: string;          // 추천 근거
+  improvement: string;     // 개선대책
+}
+
+/**
+ * Mock AI 추천 데이터
+ * 키: "{categoryId}-{subcategoryId}"
+ */
+export const MOCK_AI_RECOMMENDATIONS: Record<string, AIRecommendation[]> = {
+  // 건설업(1) - 가설전선 설치작업(101)
+  '1-101': [
+    {
+      id: 9001,
+      taskName: '가설전선 설치작업',
+      riskFactor: '안전대를 사용하지 않고 고소부위 작업중 추락',
+      accidentType: '떨어짐',
+      score: 90,
+      reason: "작업명 '가설전선' 매칭(40) + 고위험 '떨어짐'(30) + 복합매칭(20)",
+      improvement: '고소부위 작업시 안전대 고리 체결 철저'
+    },
+    {
+      id: 9002,
+      taskName: '전선작업',
+      riskFactor: '전선 접촉으로 인한 감전',
+      accidentType: '감전',
+      score: 80,
+      reason: "위험요인 '전선' 매칭(20) + 고위험 '감전'(30) + 복합매칭(30)",
+      improvement: '절연장갑 착용 및 전원 차단 후 작업'
+    },
+    {
+      id: 9003,
+      taskName: '가설전선 설치작업',
+      riskFactor: '불안전한 작업발판으로 인한 추락',
+      accidentType: '떨어짐',
+      score: 75,
+      reason: "작업명 '가설전선' 매칭(40) + 고위험 '떨어짐'(30)",
+      improvement: '안전 작업발판 설치 후 작업 실시'
+    },
+    {
+      id: 9004,
+      taskName: '전선 설치',
+      riskFactor: '젖은 손으로 전선 취급 시 감전',
+      accidentType: '감전',
+      score: 70,
+      reason: "위험요인 '전선' 매칭(20) + 고위험 '감전'(30) + 복합매칭(20)",
+      improvement: '작업 전 손 건조 확인 및 절연장갑 착용'
+    },
+    {
+      id: 9005,
+      taskName: '가설작업',
+      riskFactor: '안전난간 미설치로 인한 추락',
+      accidentType: '떨어짐',
+      score: 65,
+      reason: "작업명 '가설' 매칭(40) + 고위험 '떨어짐'(30)",
+      improvement: '작업 전 안전난간 설치 확인'
+    },
+    {
+      id: 9006,
+      taskName: '전기작업',
+      riskFactor: '차단기 미설치 상태에서 통전 작업',
+      accidentType: '감전',
+      score: 60,
+      reason: "대책 '전기' 매칭(10) + 고위험 '감전'(30) + 복합매칭(20)",
+      improvement: '작업 전 차단기 설치 및 잠금장치 실시'
+    },
+    {
+      id: 9007,
+      taskName: '설치작업',
+      riskFactor: '비계 연결 불량으로 인한 붕괴',
+      accidentType: '무너짐',
+      score: 55,
+      reason: "작업명 '설치' 매칭(40)",
+      improvement: '비계 연결부 점검 및 고정 철저'
+    },
+    {
+      id: 9008,
+      taskName: '고소작업',
+      riskFactor: '안전모 미착용으로 인한 낙하물 충격',
+      accidentType: '맞음',
+      score: 50,
+      reason: "대책 '안전모' 매칭(10) + 복합매칭(20)",
+      improvement: '작업장 출입 시 안전모 착용 의무화'
+    }
+  ],
+
+  // 건설업(1) - 가설전선 점검작업(102)
+  '1-102': [
+    {
+      id: 9011,
+      taskName: '가설전선 점검작업',
+      riskFactor: '점검 중 충전부 접촉으로 인한 감전',
+      accidentType: '감전',
+      score: 95,
+      reason: "작업명 '가설전선 점검' 매칭(40) + 고위험 '감전'(30) + 복합매칭(30)",
+      improvement: '점검 전 전원 차단 및 무전압 확인'
+    },
+    {
+      id: 9012,
+      taskName: '전선 점검',
+      riskFactor: '사다리 작업 중 균형 상실로 추락',
+      accidentType: '떨어짐',
+      score: 85,
+      reason: "위험요인 '전선' 매칭(20) + 고위험 '떨어짐'(30) + 복합매칭(30)",
+      improvement: '사다리 고정 및 보조자 배치'
+    },
+    {
+      id: 9013,
+      taskName: '점검작업',
+      riskFactor: '절연장갑 미착용으로 인한 감전',
+      accidentType: '감전',
+      score: 75,
+      reason: "작업명 '점검' 매칭(40) + 고위험 '감전'(30)",
+      improvement: '절연장갑 및 절연화 착용 필수'
+    },
+    {
+      id: 9014,
+      taskName: '전선 점검',
+      riskFactor: '경년 열화된 전선 파손으로 감전',
+      accidentType: '감전',
+      score: 70,
+      reason: "위험요인 '전선' 매칭(20) + 고위험 '감전'(30) + 복합매칭(20)",
+      improvement: '점검 시 전선 피복 상태 확인 철저'
+    },
+    {
+      id: 9015,
+      taskName: '점검작업',
+      riskFactor: '점검 중 공구 낙하로 인한 맞음',
+      accidentType: '맞음',
+      score: 60,
+      reason: "작업명 '점검' 매칭(40) + 복합매칭(20)",
+      improvement: '공구 떨어짐 방지용 끈 사용'
+    }
+  ],
+
+  // 건설업(1) - 꽂음 접속기작업(103)
+  '1-103': [
+    {
+      id: 9021,
+      taskName: '꽂음 접속기작업',
+      riskFactor: '접속기 결합 불량으로 인한 감전',
+      accidentType: '감전',
+      score: 90,
+      reason: "작업명 '꽂음 접속기' 매칭(40) + 고위험 '감전'(30) + 복합매칭(20)",
+      improvement: '접속 후 결합 상태 확인 철저'
+    },
+    {
+      id: 9022,
+      taskName: '전기 접속 작업',
+      riskFactor: '절연 파손된 접속기 사용으로 감전',
+      accidentType: '감전',
+      score: 85,
+      reason: "위험요인 '접속' 매칭(20) + 고위험 '감전'(30) + 복합매칭(30)",
+      improvement: '접속기 사용 전 외관 점검 실시'
+    },
+    {
+      id: 9023,
+      taskName: '접속작업',
+      riskFactor: '손에 물기가 있는 상태에서 접속 시 감전',
+      accidentType: '감전',
+      score: 75,
+      reason: "작업명 '접속' 매칭(40) + 고위험 '감전'(30)",
+      improvement: '작업 전 손 건조 확인 및 절연장갑 착용'
+    }
+  ],
+
+  // 건설업(1) - 이동형 릴 전선작업(104)
+  '1-104': [
+    {
+      id: 9031,
+      taskName: '이동형 릴 전선작업',
+      riskFactor: '전선 피복 손상으로 인한 감전',
+      accidentType: '감전',
+      score: 92,
+      reason: "작업명 '이동형 릴 전선' 매칭(40) + 고위험 '감전'(30) + 복합매칭(30)",
+      improvement: '작업 전 전선 피복 상태 확인'
+    },
+    {
+      id: 9032,
+      taskName: '릴 전선 작업',
+      riskFactor: '전선릴 이동 중 손 끼임',
+      accidentType: '끼임',
+      score: 80,
+      reason: "위험요인 '릴' 매칭(20) + 고위험 '끼임'(30) + 복합매칭(30)",
+      improvement: '릴 이동 시 손잡이 사용 및 장갑 착용'
+    },
+    {
+      id: 9033,
+      taskName: '전선 작업',
+      riskFactor: '과부하로 인한 전선 과열 및 화재',
+      accidentType: '화재',
+      score: 75,
+      reason: "작업명 '전선' 매칭(40) + 고위험 '화재'(30)",
+      improvement: '정격 용량 확인 및 과부하 방지'
+    }
+  ],
+
+  // 건설업(1) - 전동공구 사용/정리정돈작업(105)
+  '1-105': [
+    {
+      id: 9041,
+      taskName: '전동공구 사용작업',
+      riskFactor: '접지 미설치로 인한 감전',
+      accidentType: '감전',
+      score: 88,
+      reason: "작업명 '전동공구' 매칭(40) + 고위험 '감전'(30) + 복합매칭(20)",
+      improvement: '전동공구 접지 확인 후 사용'
+    },
+    {
+      id: 9042,
+      taskName: '공구 사용',
+      riskFactor: '회전 날에 손 접촉으로 절단',
+      accidentType: '절단/베임',
+      score: 82,
+      reason: "위험요인 '공구' 매칭(20) + 복합매칭(30)",
+      improvement: '보호장갑 착용 및 작업 중 집중'
+    },
+    {
+      id: 9043,
+      taskName: '전동공구 정리',
+      riskFactor: '전선 정리 중 걸려 넘어짐',
+      accidentType: '넘어짐',
+      score: 70,
+      reason: "작업명 '정리' 매칭(40) + 복합매칭(30)",
+      improvement: '전선 정리 시 통로 확보'
+    },
+    {
+      id: 9044,
+      taskName: '정리정돈',
+      riskFactor: '공구 낙하로 인한 맞음',
+      accidentType: '맞음',
+      score: 65,
+      reason: "작업명 '정리정돈' 매칭(40) + 복합매칭(20)",
+      improvement: '공구 보관 시 안전한 위치에 배치'
+    }
+  ],
+
+  // 추가 카테고리/소분류 조합 (예시)
+  '2-201': [
+    {
+      id: 9051,
+      taskName: '용접 작업',
+      riskFactor: '용접 불꽃으로 인한 화재',
+      accidentType: '화재',
+      score: 95,
+      reason: "작업명 '용접' 매칭(40) + 고위험 '화재'(30) + 복합매칭(30)",
+      improvement: '작업 전 가연물 제거 및 소화기 비치'
+    },
+    {
+      id: 9052,
+      taskName: '용접',
+      riskFactor: '용접 흄 흡입으로 인한 질식',
+      accidentType: '질식',
+      score: 85,
+      reason: "작업명 '용접' 매칭(40) + 고위험 '질식'(30)",
+      improvement: '환기 설비 가동 및 방독 마스크 착용'
+    }
+  ]
+};
+
+/**
+ * 카테고리/소분류 조합으로 AI 추천 조회
+ *
+ * @param categoryId 대분류 ID
+ * @param subcategoryId 소분류 ID
+ * @param limit 반환 개수 (기본 10개)
+ * @returns AI 추천 목록
+ */
+export function getAIRecommendations(
+  categoryId: number,
+  subcategoryId: number,
+  limit: number = 10
+): AIRecommendation[] {
+  const key = `${categoryId}-${subcategoryId}`;
+  const recommendations = MOCK_AI_RECOMMENDATIONS[key] || [];
+
+  // 점수 높은 순으로 정렬 후 limit만큼 반환
+  return recommendations
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}
+
+/**
+ * 실제 API 연동 시 사용할 함수 (추후 구현)
+ *
+ * @param categoryId 대분류 ID
+ * @param subcategoryId 소분류 ID
+ * @param limit 반환 개수
+ * @returns Promise<AIRecommendation[]>
+ */
+export async function fetchAIRecommendations(
+  categoryId: number,
+  subcategoryId: number,
+  limit: number = 10
+): Promise<AIRecommendation[]> {
+  // TODO: 실제 백엔드 API 호출로 교체
+  // const response = await fetch('/api/risk-assessment/recommend', {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/json' },
+  //   body: JSON.stringify({ categoryId, subcategoryId, limit })
+  // });
+  // return await response.json();
+
+  // 현재는 Mock 데이터 반환
+  return Promise.resolve(getAIRecommendations(categoryId, subcategoryId, limit));
+}

--- a/apps/admin-web/src/mocks/teams.ts
+++ b/apps/admin-web/src/mocks/teams.ts
@@ -1,0 +1,115 @@
+/**
+ * 팀(업체) Mock 데이터
+ */
+
+export interface Team {
+  id: string;
+  name: string;
+  companyId: string;
+  siteId?: string;
+  type: 'CONTRACTOR' | 'SUBCONTRACTOR' | 'PARTNER';
+  contactPerson?: string;
+  contactPhone?: string;
+  businessNumber?: string;
+  isActive: boolean;
+}
+
+/**
+ * Mock 팀 데이터
+ */
+export const MOCK_TEAMS: Team[] = [
+  {
+    id: 'team-001',
+    name: '(주)정이앤지',
+    companyId: 'company-001',
+    siteId: 'site-001',
+    type: 'CONTRACTOR',
+    contactPerson: '김현장',
+    contactPhone: '010-1234-5678',
+    businessNumber: '123-45-67890',
+    isActive: true,
+  },
+  {
+    id: 'team-002',
+    name: '협력업체A',
+    companyId: 'company-001',
+    siteId: 'site-001',
+    type: 'SUBCONTRACTOR',
+    contactPerson: '이팀장',
+    contactPhone: '010-2345-6789',
+    businessNumber: '234-56-78901',
+    isActive: true,
+  },
+  {
+    id: 'team-003',
+    name: '협력업체B',
+    companyId: 'company-001',
+    siteId: 'site-001',
+    type: 'SUBCONTRACTOR',
+    contactPerson: '박소장',
+    contactPhone: '010-3456-7890',
+    businessNumber: '345-67-89012',
+    isActive: true,
+  },
+  {
+    id: 'team-004',
+    name: '(주)대한건설',
+    companyId: 'company-001',
+    siteId: 'site-001',
+    type: 'PARTNER',
+    contactPerson: '최관리',
+    contactPhone: '010-4567-8901',
+    businessNumber: '456-78-90123',
+    isActive: true,
+  },
+  {
+    id: 'team-005',
+    name: '한국안전산업',
+    companyId: 'company-001',
+    siteId: 'site-001',
+    type: 'PARTNER',
+    contactPerson: '정기사',
+    contactPhone: '010-5678-9012',
+    businessNumber: '567-89-01234',
+    isActive: true,
+  },
+  {
+    id: 'team-006',
+    name: '비활성업체',
+    companyId: 'company-001',
+    siteId: 'site-001',
+    type: 'SUBCONTRACTOR',
+    contactPerson: '홍담당',
+    contactPhone: '010-6789-0123',
+    businessNumber: '678-90-12345',
+    isActive: false,
+  },
+];
+
+/**
+ * 활성화된 팀 목록 가져오기
+ */
+export function getActiveTeams(): Team[] {
+  return MOCK_TEAMS.filter(team => team.isActive);
+}
+
+/**
+ * ID로 팀 찾기
+ */
+export function getTeamById(id: string): Team | undefined {
+  return MOCK_TEAMS.find(team => team.id === id);
+}
+
+/**
+ * 회사 ID로 팀 목록 가져오기
+ */
+export function getTeamsByCompanyId(companyId: string): Team[] {
+  return MOCK_TEAMS.filter(team => team.companyId === companyId && team.isActive);
+}
+
+/**
+ * 현장 ID로 팀 목록 가져오기
+ */
+export function getTeamsBySiteId(siteId: string): Team[] {
+  return MOCK_TEAMS.filter(team => team.siteId === siteId && team.isActive);
+}

--- a/apps/admin-web/src/pages/RiskAssessmentPage.tsx
+++ b/apps/admin-web/src/pages/RiskAssessmentPage.tsx
@@ -732,9 +732,9 @@ export default function RiskAssessmentPage() {
 
           <div>
 
-            <h1 className="text-xl font-black tracking-tight text-slate-800">위험성 평가</h1>
+            <h1 className="text-2xl font-black tracking-tight text-slate-800">위험성 평가</h1>
 
-            <p className="text-sm text-slate-500 mt-1">현장의 위험성평가 문서를 관리합니다</p>
+            <p className="text-base text-slate-500 mt-1">현장의 위험성평가 문서를 관리합니다</p>
 
           </div>
 
@@ -766,7 +766,7 @@ export default function RiskAssessmentPage() {
 
         <div className="flex items-center gap-4">
 
-          <span className="text-sm font-medium text-slate-600">구분</span>
+          <span className="text-base font-medium text-slate-600">구분</span>
 
           <div className="flex gap-2">
 
@@ -774,7 +774,7 @@ export default function RiskAssessmentPage() {
 
               onClick={() => setFilterType('ALL')}
 
-              className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors
+              className={`px-4 py-2 text-base font-medium rounded-lg transition-colors
 
                 ${filterType === 'ALL'
 
@@ -798,7 +798,7 @@ export default function RiskAssessmentPage() {
 
                 onClick={() => setFilterType(type.id)}
 
-                className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors
+                className={`px-4 py-2 text-base font-medium rounded-lg transition-colors
 
                   ${filterType === type.id
 
@@ -832,19 +832,19 @@ export default function RiskAssessmentPage() {
 
               <tr>
 
-                <th className="px-4 py-3 text-left text-xs font-bold text-slate-500 uppercase">작업기간</th>
+                <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">작업기간</th>
 
-                <th className="px-4 py-3 text-left text-xs font-bold text-slate-500 uppercase">작업공종(대분류)</th>
+                <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">작업공종(대분류)</th>
 
-                <th className="px-4 py-3 text-left text-xs font-bold text-slate-500 uppercase">작업자</th>
+                <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">작업자</th>
 
-                <th className="px-4 py-3 text-left text-xs font-bold text-slate-500 uppercase">구분</th>
+                <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">구분</th>
 
-                <th className="px-4 py-3 text-left text-xs font-bold text-slate-500 uppercase">상태</th>
+                <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">상태</th>
 
-                <th className="px-4 py-3 text-left text-xs font-bold text-slate-500 uppercase">결재 근로자</th>
+                <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">결재 근로자</th>
 
-                <th className="px-4 py-3 text-left text-xs font-bold text-slate-500 uppercase">근 미확인 근로자</th>
+                <th className="px-4 py-3 text-left text-sm font-bold text-slate-500 uppercase">근 미확인 근로자</th>
 
               </tr>
 
@@ -879,19 +879,19 @@ export default function RiskAssessmentPage() {
 
                   >
 
-                    <td className="px-4 py-4 text-sm text-slate-600">
+                    <td className="px-4 py-4 text-base text-slate-600">
 
                       {assessment.workPeriodStart.slice(5)} ~ {assessment.workPeriodEnd.slice(5)}
 
                     </td>
 
-                    <td className="px-4 py-4 text-sm text-slate-700 font-medium">
+                    <td className="px-4 py-4 text-base text-slate-700 font-medium">
 
                       {assessment.workCategory}
 
                     </td>
 
-                    <td className="px-4 py-4 text-sm text-slate-600">
+                    <td className="px-4 py-4 text-base text-slate-600">
 
                       {assessment.assignee}
 
@@ -899,7 +899,7 @@ export default function RiskAssessmentPage() {
 
                     <td className="px-4 py-4">
 
-                      <span className="text-sm text-slate-600">
+                      <span className="text-base text-slate-600">
 
                         {typeInfo?.shortLabel} 위험성평가
 
@@ -909,7 +909,7 @@ export default function RiskAssessmentPage() {
 
                     <td className="px-4 py-4">
 
-                      <span className={`px-2 py-1 text-xs font-medium rounded ${statusInfo.color}`}>
+                      <span className={`px-2 py-1 text-sm font-medium rounded ${statusInfo.color}`}>
 
                         {statusInfo.label}
 
@@ -917,13 +917,13 @@ export default function RiskAssessmentPage() {
 
                     </td>
 
-                    <td className="px-4 py-4 text-sm text-slate-600">
+                    <td className="px-4 py-4 text-base text-slate-600">
 
                       {assessment.workerCount}명
 
                     </td>
 
-                    <td className="px-4 py-4 text-sm">
+                    <td className="px-4 py-4 text-base">
 
                       {assessment.unconfirmedCount && assessment.unconfirmedCount > 0 ? (
 
@@ -955,9 +955,9 @@ export default function RiskAssessmentPage() {
 
               <FileText size={48} className="mx-auto mb-4 text-slate-300" />
 
-              <p className="text-slate-500 font-medium">등록된 위험성평가가 없습니다</p>
+              <p className="text-base text-slate-500 font-medium">등록된 위험성평가가 없습니다</p>
 
-              <p className="text-sm text-slate-400 mt-1">위험성평가를 추가해주세요</p>
+              <p className="text-base text-slate-400 mt-1">위험성평가를 추가해주세요</p>
 
             </div>
 
@@ -971,19 +971,19 @@ export default function RiskAssessmentPage() {
 
         <div className="flex justify-center gap-1">
 
-          <button className="w-8 h-8 flex items-center justify-center text-sm text-slate-400">&lt;</button>
+          <button className="w-10 h-10 flex items-center justify-center text-base text-slate-400">&lt;</button>
 
-          <button className="w-8 h-8 flex items-center justify-center text-sm font-bold text-white bg-orange-500 rounded">1</button>
+          <button className="w-10 h-10 flex items-center justify-center text-base font-bold text-white bg-orange-500 rounded">1</button>
 
-          <button className="w-8 h-8 flex items-center justify-center text-sm text-slate-600 hover:bg-gray-100 rounded">2</button>
+          <button className="w-10 h-10 flex items-center justify-center text-base text-slate-600 hover:bg-gray-100 rounded">2</button>
 
-          <button className="w-8 h-8 flex items-center justify-center text-sm text-slate-600 hover:bg-gray-100 rounded">3</button>
+          <button className="w-10 h-10 flex items-center justify-center text-base text-slate-600 hover:bg-gray-100 rounded">3</button>
 
-          <button className="w-8 h-8 flex items-center justify-center text-sm text-slate-600 hover:bg-gray-100 rounded">4</button>
+          <button className="w-10 h-10 flex items-center justify-center text-base text-slate-600 hover:bg-gray-100 rounded">4</button>
 
-          <button className="w-8 h-8 flex items-center justify-center text-sm text-slate-600 hover:bg-gray-100 rounded">5</button>
+          <button className="w-10 h-10 flex items-center justify-center text-base text-slate-600 hover:bg-gray-100 rounded">5</button>
 
-          <button className="w-8 h-8 flex items-center justify-center text-sm text-slate-400">&gt;</button>
+          <button className="w-10 h-10 flex items-center justify-center text-base text-slate-400">&gt;</button>
 
         </div>
 

--- a/apps/admin-web/src/pages/risk-assessment/CreateAssessmentPage.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/CreateAssessmentPage.tsx
@@ -38,17 +38,17 @@ export default function CreateAssessmentPage() {
     setSubmitStatus(null);
 
     try {
-      const draftId = `draft-${Date.now()}`;
+      const docId = `doc-${Date.now()}`;
       const payload = {
-        id: draftId,
+        id: docId,
         ...data,
         type: assessmentType,
         created_at: new Date().toISOString(),
-        status: 'DRAFT',
+        status: 'PENDING', // 바로 결재대기 상태로 생성
       };
 
       try {
-        localStorage.setItem(`risk-assessment:draft:${draftId}`, JSON.stringify(payload));
+        localStorage.setItem(`risk-assessment:draft:${docId}`, JSON.stringify(payload));
       } catch (storageError) {
         console.error('로컬 저장 실패:', storageError);
       }
@@ -58,7 +58,7 @@ export default function CreateAssessmentPage() {
       setSubmitStatus('success');
 
       setTimeout(() => {
-        navigate(`/safety/risk/${draftId}`);
+        navigate(`/safety/risk/${docId}`);
       }, 1500);
     } catch (error) {
       console.error('평가 생성 실패:', error);
@@ -144,7 +144,29 @@ export default function CreateAssessmentPage() {
       )}
 
       {(assessmentType === 'ADHOC' || assessmentType === 'FREQUENCY_INTENSITY') && (
-        <AdHocAssessmentForm onSubmit={handleSubmit} onCancel={handleCancel} />
+        <div className="bg-white rounded-xl border border-gray-200 p-12">
+          <div className="text-center">
+            <div className="mb-4">
+              <svg className="mx-auto h-16 w-16 text-orange-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+            </div>
+            <h3 className="text-xl font-bold text-slate-700 mb-2">
+              {typeLabel} 위험성평가 개발중
+            </h3>
+            <p className="text-base text-slate-500 mb-6">
+              해당 유형의 위험성평가는 현재 개발중입니다.<br />
+              최초 위험성평가만 이용 가능합니다.
+            </p>
+            <button
+              type="button"
+              onClick={handleBack}
+              className="px-6 py-3 rounded-xl font-bold text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 transition-all"
+            >
+              목록으로 돌아가기
+            </button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/apps/admin-web/src/pages/risk-assessment/CreateAssessmentPage.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/CreateAssessmentPage.tsx
@@ -84,12 +84,12 @@ export default function CreateAssessmentPage() {
           >
             <ChevronLeft size={20} className="text-slate-600" />
           </button>
-          <h1 className="text-xl font-black tracking-tight text-slate-800">
+          <h1 className="text-2xl font-black tracking-tight text-slate-800">
             위험성평가 만들기
           </h1>
         </div>
         <div className="bg-white rounded-xl border border-gray-200 p-8">
-          <p className="text-slate-500 text-center">
+          <p className="text-base text-slate-500 text-center">
             지원하지 않는 평가 유형입니다.
           </p>
         </div>
@@ -107,7 +107,7 @@ export default function CreateAssessmentPage() {
         >
           <ChevronLeft size={20} className="text-slate-600" />
         </button>
-        <h1 className="text-xl font-black tracking-tight text-slate-800">
+        <h1 className="text-2xl font-black tracking-tight text-slate-800">
           {typeLabel} 위험성평가 만들기
         </h1>
       </div>
@@ -115,14 +115,14 @@ export default function CreateAssessmentPage() {
       {submitStatus === 'success' && (
         <div className="p-4 rounded-xl bg-green-50 border border-green-200 flex items-center gap-3">
           <CheckCircle className="w-5 h-5 text-green-600" />
-          <p className="text-green-800 font-medium">평가가 성공적으로 생성되었습니다.</p>
+          <p className="text-base text-green-800 font-medium">평가가 성공적으로 생성되었습니다.</p>
         </div>
       )}
 
       {submitStatus === 'error' && (
         <div className="p-4 rounded-xl bg-red-50 border border-red-200 flex items-center gap-3">
           <AlertCircle className="w-5 h-5 text-red-600" />
-          <p className="text-red-800 font-medium">평가 생성 중 오류가 발생했습니다. 다시 시도해주세요.</p>
+          <p className="text-base text-red-800 font-medium">평가 생성 중 오류가 발생했습니다. 다시 시도해주세요.</p>
         </div>
       )}
 
@@ -130,7 +130,7 @@ export default function CreateAssessmentPage() {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
           <div className="bg-white rounded-2xl p-8 text-center">
             <div className="inline-block animate-spin rounded-full h-12 w-12 border-4 border-orange-500 border-t-transparent mb-4"></div>
-            <p className="text-slate-700 font-bold">평가를 생성하는 중...</p>
+            <p className="text-lg text-slate-700 font-bold">평가를 생성하는 중...</p>
           </div>
         </div>
       )}

--- a/apps/admin-web/src/pages/risk-assessment/LegacyInitialAssessmentPage.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/LegacyInitialAssessmentPage.tsx
@@ -14,6 +14,7 @@ import SubcategoryAddModal from './modals/SubcategoryAddModal';
 import RiskFactorSelectModal from './modals/RiskFactorSelectModal';
 import SuccessModal from './modals/SuccessModal';
 import { useApprovalLines } from '@/stores/approvalLinesStore';
+import { getActiveTeams } from '@/mocks/teams';
 
 let idCounter = 0;
 const generateId = () => `temp-${Date.now()}-${++idCounter}`;
@@ -48,9 +49,12 @@ export default function LegacyInitialAssessmentPage() {
 
   const [siteName] = useState('통사통사현장');
   const [companyName] = useState('(주)통하는사람들');
+  const [teamId, setTeamId] = useState<string>('all');
   const [workPeriodStart, setWorkPeriodStart] = useState('2026-01-01');
   const [workPeriodEnd, setWorkPeriodEnd] = useState('2026-01-31');
   const [approvalModalOpen, setApprovalModalOpen] = useState(false);
+
+  const teams = useMemo(() => getActiveTeams(), []);
 
   const approvalLines = useApprovalLines();
   const availableApprovalLines = useMemo(() => approvalLines, [approvalLines]);
@@ -328,6 +332,8 @@ export default function LegacyInitialAssessmentPage() {
         <BasicInfoSection
           siteName={siteName}
           companyName={companyName}
+          teamId={teamId}
+          teams={teams}
           approvalLineName={selectedApprovalLine?.name || null}
           approvalLineCount={selectedApprovalLine?.approvers.length || null}
           approvalLineApprovers={
@@ -343,6 +349,7 @@ export default function LegacyInitialAssessmentPage() {
             if (field === 'start') setWorkPeriodStart(value);
             else setWorkPeriodEnd(value);
           }}
+          onTeamChange={setTeamId}
         />
 
         <div className="space-y-6">

--- a/apps/admin-web/src/pages/risk-assessment/LegacyInitialAssessmentPage.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/LegacyInitialAssessmentPage.tsx
@@ -320,7 +320,7 @@ export default function LegacyInitialAssessmentPage() {
           >
             <ChevronLeft size={20} className="text-slate-600" />
           </button>
-          <h1 className="text-xl font-black tracking-tight text-slate-800">
+          <h1 className="text-2xl font-black tracking-tight text-slate-800">
             최초 위험성 평가 만들기 (레거시)
           </h1>
         </div>

--- a/apps/admin-web/src/pages/risk-assessment/LegacyInitialAssessmentPage.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/LegacyInitialAssessmentPage.tsx
@@ -53,11 +53,7 @@ export default function LegacyInitialAssessmentPage() {
   const [approvalModalOpen, setApprovalModalOpen] = useState(false);
 
   const approvalLines = useApprovalLines();
-  const availableApprovalLines = useMemo(() => {
-    return approvalLines.filter((line) =>
-      line.tags.includes('RISK_ASSESSMENT') || line.tags.includes('GENERAL')
-    );
-  }, [approvalLines]);
+  const availableApprovalLines = useMemo(() => approvalLines, [approvalLines]);
 
   const defaultApprovalLine = useMemo(() => {
     const pinned = availableApprovalLines.find((line) => line.isPinned);

--- a/apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx
@@ -6,6 +6,7 @@ import ApprovalLineSelectModal from './modals/ApprovalLineSelectModal';
 import ConfirmDialog from '@/components/common/ConfirmDialog';
 import { getAssessmentById, type MockRiskAssessment } from '@/mocks/risk-assessment';
 import { useApprovalLines } from '@/stores/approvalLinesStore';
+import { getActiveTeams } from '@/mocks/teams';
 import type { ApprovalLine, Approver } from '@tong-pass/shared';
 
 const STATUS_LABELS: Record<string, { label: string; className: string }> = {
@@ -189,9 +190,12 @@ export default function RiskAssessmentDetailPage() {
   const [workPeriodEnd, setWorkPeriodEnd] = useState(
     localAssessment?.workPeriodEnd || assessment?.work_end_date || ''
   );
+  const [teamId, setTeamId] = useState<string>('all');
   const [items, setItems] = useState(
     localAssessment ? buildItemsFromCategories(localAssessment.categories) : assessment?.items || []
   );
+
+  const teams = useMemo(() => getActiveTeams(), []);
 
   useEffect(() => {
     if (!selectedApprovalLine || !availableApprovalLines.some((line) => line.id === selectedApprovalLine.id)) {
@@ -360,8 +364,9 @@ export default function RiskAssessmentDetailPage() {
       <BasicInfoSection
         assessmentTitle={localAssessment?.title || mergedAssessment?.title || ''}
         siteName={displaySiteName}
-        teamName={displayTeamName}
         companyName={displayCompanyName}
+        teamId={teamId}
+        teams={teams}
         approvalLineName={selectedApprovalLine?.name || null}
         approvalLineCount={selectedApprovalLine?.approvers.length || null}
         approvalLineApprovers={approvalLineApprovers.map((approver) => ({
@@ -374,7 +379,9 @@ export default function RiskAssessmentDetailPage() {
         workPeriodEnd={workPeriodEnd}
         onApprovalLineChange={() => setApprovalModalOpen(true)}
         onDateChange={handleDateChange}
+        onTeamChange={setTeamId}
         canChangeApprovalLine={canEdit}
+        canChangeTeam={canEdit}
         disableStartDate={disableStartDate}
         disableEndDate={disableEndDate}
         signatures={appliedSignatures}

--- a/apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx
@@ -315,7 +315,6 @@ export default function RiskAssessmentDetailPage() {
           </button>
           <div>
             <h1 className="text-2xl font-black tracking-tight text-slate-800">위험성평가 상세</h1>
-            <p className="text-base text-slate-500 mt-1">문서 번호: {documentId}</p>
           </div>
         </div>
         <div className="flex items-center gap-2">

--- a/apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx
@@ -122,7 +122,7 @@ function SignatureBox({
   return (
     <div className="border border-dashed border-gray-300 rounded-lg p-3 min-h-[72px] flex flex-col justify-between">
       {signature ? (
-        <div className="text-sm text-slate-700">
+        <div className="text-base text-slate-700">
           {signature.startsWith('data:image') ? (
             <img src={signature} alt="전자서명" className="h-10 object-contain" />
           ) : (
@@ -130,14 +130,14 @@ function SignatureBox({
           )}
         </div>
       ) : (
-        <span className="text-xs text-slate-400">서명 필요</span>
+        <span className="text-sm text-slate-400">서명 필요</span>
       )}
       <button
         type="button"
         onClick={onApply}
         disabled={!canApply}
         title={storedSignature ? '' : '저장된 서명이 없습니다.'}
-        className="mt-2 text-xs font-bold text-orange-600 hover:text-orange-700 disabled:text-slate-300"
+        className="mt-2 text-sm font-bold text-orange-600 hover:text-orange-700 disabled:text-slate-300"
       >
         서명 불러오기
       </button>
@@ -222,7 +222,7 @@ export default function RiskAssessmentDetailPage() {
     return (
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-xl font-black tracking-tight text-slate-800">위험성평가 상세</h1>
+          <h1 className="text-2xl font-black tracking-tight text-slate-800">위험성평가 상세</h1>
           <button
             type="button"
             onClick={() => navigate('/safety/risk')}
@@ -310,8 +310,8 @@ export default function RiskAssessmentDetailPage() {
             <ChevronLeft size={18} />
           </button>
           <div>
-            <h1 className="text-xl font-black tracking-tight text-slate-800">위험성평가 상세</h1>
-            <p className="text-sm text-slate-500 mt-1">문서 번호: {documentId}</p>
+            <h1 className="text-2xl font-black tracking-tight text-slate-800">위험성평가 상세</h1>
+            <p className="text-base text-slate-500 mt-1">문서 번호: {documentId}</p>
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -350,10 +350,10 @@ export default function RiskAssessmentDetailPage() {
 
       <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
         <div className="flex items-center gap-3">
-          <span className={`px-2 py-1 text-xs font-medium rounded ${statusInfo.className}`}>
+          <span className={`px-2 py-1 text-sm font-medium rounded ${statusInfo.className}`}>
             {statusInfo.label}
           </span>
-          <span className="text-sm text-slate-500">{TYPE_LABELS[assessmentType] || assessmentType} 위험성평가</span>
+          <span className="text-base text-slate-500">{TYPE_LABELS[assessmentType] || assessmentType} 위험성평가</span>
         </div>
       </div>
 
@@ -383,21 +383,21 @@ export default function RiskAssessmentDetailPage() {
       />
 
       <div className="space-y-6">
-        <h2 className="text-lg font-bold text-slate-700">작업 공종</h2>
+        <h2 className="text-xl font-bold text-slate-700">작업 공종</h2>
 
         {localAssessment ? (
           <div className="space-y-6">
             {localAssessment.categories.length === 0 && (
-              <div className="text-sm text-slate-500">작업 공종이 없습니다.</div>
+              <div className="text-base text-slate-500">작업 공종이 없습니다.</div>
             )}
             {localAssessment.categories.map((category, index) => (
               <div key={category.id} className="bg-gray-50 rounded-xl border border-gray-200 p-6 space-y-4">
                 {/* 대분류 헤더 */}
                 <div>
-                  <label className="block text-sm font-medium text-slate-600 mb-2">
+                  <label className="block text-base font-medium text-slate-600 mb-2">
                     대분류{index + 1}
                   </label>
-                  <div className="px-4 py-2 bg-white border border-gray-300 rounded-lg text-sm text-slate-800">
+                  <div className="px-4 py-2 bg-white border border-gray-300 rounded-lg text-base text-slate-800">
                     {category.categoryName || '-'}
                   </div>
                 </div>
@@ -410,7 +410,7 @@ export default function RiskAssessmentDetailPage() {
                   return (
                     <div key={subcategory.id} className="bg-orange-50/30 rounded-lg p-4 ml-4 space-y-4">
                       {/* 소분류 헤더 */}
-                      <h4 className="text-sm font-bold text-slate-700">
+                      <h4 className="text-base font-bold text-slate-700">
                         소분류{circledNumbers[subIndex] || `${subIndex + 1}`} {subcategory.name}
                       </h4>
 
@@ -436,7 +436,7 @@ export default function RiskAssessmentDetailPage() {
                             <div key={factor.id} className={`rounded-xl p-4 space-y-4 ${getLevelStyles()}`}>
                               {/* 위험 요인 */}
                               <div>
-                                <label className="block text-sm font-medium text-slate-600 mb-2">
+                                <label className="block text-base font-medium text-slate-600 mb-2">
                                   위험 요인
                                 </label>
                                 {canEdit ? (
@@ -452,10 +452,10 @@ export default function RiskAssessmentDetailPage() {
                                         )
                                       )
                                     }
-                                    className="w-full px-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
+                                    className="w-full px-4 py-2 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
                                   />
                                 ) : (
-                                  <div className="px-4 py-2 text-sm text-slate-800">
+                                  <div className="px-4 py-2 text-base text-slate-800">
                                     {factor.factor}
                                   </div>
                                 )}
@@ -464,7 +464,7 @@ export default function RiskAssessmentDetailPage() {
                               {/* 위험성 수준 */}
                               <div>
                                 <div className="flex items-center gap-6">
-                                  <span className="text-sm font-medium text-slate-600">위험성 수준</span>
+                                  <span className="text-base font-medium text-slate-600">위험성 수준</span>
                                   {canEdit ? (
                                     <div className="flex items-center gap-4">
                                       {[
@@ -489,19 +489,19 @@ export default function RiskAssessmentDetailPage() {
                                             }}
                                             className="w-4 h-4 text-orange-500 focus:ring-orange-500"
                                           />
-                                          <span className="text-sm text-slate-700">{option.label}</span>
+                                          <span className="text-base text-slate-700">{option.label}</span>
                                         </label>
                                       ))}
                                     </div>
                                   ) : (
-                                    <span className="text-sm text-slate-700">{levelLabel || '-'}</span>
+                                    <span className="text-base text-slate-700">{levelLabel || '-'}</span>
                                   )}
                                 </div>
                               </div>
 
                               {/* 개선 대책 */}
                               <div>
-                                <label className="block text-sm font-medium text-slate-600 mb-2">
+                                <label className="block text-base font-medium text-slate-600 mb-2">
                                   개선 대책
                                 </label>
                                 {canEdit ? (
@@ -517,10 +517,10 @@ export default function RiskAssessmentDetailPage() {
                                         )
                                       )
                                     }
-                                    className="w-full px-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
+                                    className="w-full px-4 py-2 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
                                   />
                                 ) : (
-                                  <div className="px-4 py-2 text-sm text-slate-700">
+                                  <div className="px-4 py-2 text-base text-slate-700">
                                     {factor.improvement || '-'}
                                   </div>
                                 )}
@@ -528,7 +528,7 @@ export default function RiskAssessmentDetailPage() {
 
                               {/* 작업 기간 */}
                               <div>
-                                <label className="block text-sm font-medium text-slate-600 mb-2">
+                                <label className="block text-base font-medium text-slate-600 mb-2">
                                   작업 기간
                                 </label>
                                 <div className="flex items-center gap-3">
@@ -537,7 +537,7 @@ export default function RiskAssessmentDetailPage() {
                                       type="date"
                                       value={factor.workPeriodStart}
                                       disabled={!canEdit}
-                                      className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 disabled:bg-gray-100 disabled:text-slate-500"
+                                      className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 disabled:bg-gray-100 disabled:text-slate-500"
                                       readOnly
                                     />
                                     <Calendar className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
@@ -548,7 +548,7 @@ export default function RiskAssessmentDetailPage() {
                                       type="date"
                                       value={factor.workPeriodEnd}
                                       disabled={!canEdit}
-                                      className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 disabled:bg-gray-100 disabled:text-slate-500"
+                                      className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 disabled:bg-gray-100 disabled:text-slate-500"
                                       readOnly
                                     />
                                     <Calendar className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
@@ -568,15 +568,15 @@ export default function RiskAssessmentDetailPage() {
         ) : (
           <div className="bg-gray-50 rounded-xl border border-gray-200 p-6">
             <div>
-              <label className="block text-sm font-medium text-slate-600 mb-2">대분류</label>
-              <div className="px-4 py-2 bg-white border border-gray-300 rounded-lg text-sm text-slate-800">
+              <label className="block text-base font-medium text-slate-600 mb-2">대분류</label>
+              <div className="px-4 py-2 bg-white border border-gray-300 rounded-lg text-base text-slate-800">
                 {mergedAssessment?.category_name || '-'}
               </div>
             </div>
             {mergedAssessment?.subcategory_name && (
               <div className="mt-4">
-                <label className="block text-sm font-medium text-slate-600 mb-2">세부 공종</label>
-                <div className="px-3 py-1.5 bg-orange-50 text-orange-700 text-sm rounded-lg border border-orange-200 inline-block">
+                <label className="block text-base font-medium text-slate-600 mb-2">세부 공종</label>
+                <div className="px-3 py-1.5 bg-orange-50 text-orange-700 text-base rounded-lg border border-orange-200 inline-block">
                   {mergedAssessment.subcategory_name}
                 </div>
               </div>

--- a/apps/admin-web/src/pages/risk-assessment/components/BasicInfoSection.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/components/BasicInfoSection.tsx
@@ -1,18 +1,24 @@
 ﻿/**
  * 기본 정보 섹션 - 최초 위험성평가
  *
- * 현장명, 업체, 소속회사, 결재라인, 작업기간, 위험성 수준
+ * 현장명, 소속(회사+팀), 결재라인, 작업기간, 위험성 수준
  */
 
-import { Calendar } from 'lucide-react';
+import { Calendar, ChevronDown } from 'lucide-react';
 import ApprovalLineDisplay from '@/components/approval/ApprovalLineDisplay';
 import type { Approver } from '@tong-pass/shared';
+
+interface Team {
+  id: string;
+  name: string;
+}
 
 interface BasicInfoSectionProps {
   assessmentTitle?: string;
   siteName: string;
-  teamName?: string;
   companyName: string;
+  teamId?: string;
+  teams?: Team[];
   approvalLineName: string | null;
   approvalLineCount: number | null;
   approvalLineApprovers: Approver[];
@@ -20,7 +26,9 @@ interface BasicInfoSectionProps {
   workPeriodEnd: string;
   onApprovalLineChange: () => void;
   onDateChange: (field: 'start' | 'end', value: string) => void;
+  onTeamChange?: (teamId: string) => void;
   canChangeApprovalLine?: boolean;
+  canChangeTeam?: boolean;
   disableStartDate?: boolean;
   disableEndDate?: boolean;
   signatures?: Record<string, string>;
@@ -31,8 +39,9 @@ interface BasicInfoSectionProps {
 export default function BasicInfoSection({
   assessmentTitle,
   siteName,
-  teamName,
   companyName,
+  teamId,
+  teams = [],
   approvalLineName,
   approvalLineCount,
   approvalLineApprovers,
@@ -40,13 +49,19 @@ export default function BasicInfoSection({
   workPeriodEnd,
   onApprovalLineChange,
   onDateChange,
+  onTeamChange,
   canChangeApprovalLine = true,
+  canChangeTeam = true,
   disableStartDate = false,
   disableEndDate = false,
   signatures = {},
   onApplySignature,
   canEdit = true,
 }: BasicInfoSectionProps) {
+  const selectedTeam = teams.find(t => t.id === teamId);
+  const teamDisplayText = teamId && teamId !== 'all'
+    ? selectedTeam?.name || '선택된 팀'
+    : '전체 (팀 미지정)';
   return (
     <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-6">
       <h3 className="text-xl font-bold text-slate-700">기본 정보</h3>
@@ -63,16 +78,39 @@ export default function BasicInfoSection({
         <span className="text-slate-800">{siteName}</span>
       </div>
 
-      {teamName && (
-        <div className="flex items-center gap-4">
-          <label className="text-base font-medium text-slate-600 w-24">업체</label>
-          <span className="text-slate-800">{teamName}</span>
-        </div>
-      )}
+      <div>
+        <label className="block text-base font-medium text-slate-600 mb-2">소속</label>
+        <div className="space-y-3">
+          {/* 회사 (고정) */}
+          <div className="flex items-center gap-4">
+            <label className="text-base font-medium text-slate-600 w-20">회사</label>
+            <span className="text-slate-800">{companyName}</span>
+          </div>
 
-      <div className="flex items-center gap-4">
-        <label className="text-base font-medium text-slate-600 w-24">소속 회사</label>
-        <span className="text-slate-800">{companyName}</span>
+          {/* 팀 선택 */}
+          <div className="flex items-center gap-4">
+            <label className="text-base font-medium text-slate-600 w-20">팀(업체)</label>
+            {canChangeTeam && onTeamChange ? (
+              <div className="relative flex-1 max-w-md">
+                <select
+                  value={teamId || 'all'}
+                  onChange={(e) => onTeamChange(e.target.value)}
+                  className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 appearance-none bg-white"
+                >
+                  <option value="all">전체 (팀 미지정)</option>
+                  {teams.map((team) => (
+                    <option key={team.id} value={team.id}>
+                      {team.name}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400 pointer-events-none" />
+              </div>
+            ) : (
+              <span className="text-slate-800">{teamDisplayText}</span>
+            )}
+          </div>
+        </div>
       </div>
 
       <div className="flex items-center gap-4">

--- a/apps/admin-web/src/pages/risk-assessment/components/BasicInfoSection.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/components/BasicInfoSection.tsx
@@ -49,36 +49,36 @@ export default function BasicInfoSection({
 }: BasicInfoSectionProps) {
   return (
     <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-6">
-      <h3 className="text-lg font-bold text-slate-700">기본 정보</h3>
+      <h3 className="text-xl font-bold text-slate-700">기본 정보</h3>
 
       {assessmentTitle && (
         <div className="flex items-center gap-4">
-          <label className="text-sm font-medium text-slate-600 w-24">평가명</label>
+          <label className="text-base font-medium text-slate-600 w-24">평가명</label>
           <span className="text-slate-800">{assessmentTitle}</span>
         </div>
       )}
 
       <div className="flex items-center gap-4">
-        <label className="text-sm font-medium text-slate-600 w-24">현장명</label>
+        <label className="text-base font-medium text-slate-600 w-24">현장명</label>
         <span className="text-slate-800">{siteName}</span>
       </div>
 
       {teamName && (
         <div className="flex items-center gap-4">
-          <label className="text-sm font-medium text-slate-600 w-24">업체</label>
+          <label className="text-base font-medium text-slate-600 w-24">업체</label>
           <span className="text-slate-800">{teamName}</span>
         </div>
       )}
 
       <div className="flex items-center gap-4">
-        <label className="text-sm font-medium text-slate-600 w-24">소속 회사</label>
+        <label className="text-base font-medium text-slate-600 w-24">소속 회사</label>
         <span className="text-slate-800">{companyName}</span>
       </div>
 
       <div className="flex items-center gap-4">
-        <label className="text-sm font-medium text-slate-600 w-24">결재 라인</label>
+        <label className="text-base font-medium text-slate-600 w-24">결재 라인</label>
         <div className="flex items-center gap-3 flex-1">
-          <span className="text-sm text-slate-700">
+          <span className="text-base text-slate-700">
             {approvalLineName
               ? `${approvalLineName}${approvalLineCount ? ` · ${approvalLineCount}명` : ''}`
               : '선택된 결재라인 없음'}
@@ -87,7 +87,7 @@ export default function BasicInfoSection({
             <button
               type="button"
               onClick={onApprovalLineChange}
-              className="text-sm text-orange-600 hover:text-orange-700 font-medium"
+              className="text-base text-orange-600 hover:text-orange-700 font-medium"
             >
               결재라인 변경
             </button>
@@ -104,7 +104,7 @@ export default function BasicInfoSection({
       />
 
       <div>
-        <label className="block text-sm font-medium text-slate-600 mb-2">작업 기간</label>
+        <label className="block text-base font-medium text-slate-600 mb-2">작업 기간</label>
         <div className="flex items-center gap-3">
           <div className="relative">
             <input
@@ -112,7 +112,7 @@ export default function BasicInfoSection({
               value={workPeriodStart}
               onChange={(e) => onDateChange('start', e.target.value)}
               disabled={disableStartDate}
-              className="px-4 py-2 pr-10 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 disabled:bg-gray-100 disabled:text-slate-500"
+              className="px-4 py-2 pr-10 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 disabled:bg-gray-100 disabled:text-slate-500"
             />
             <Calendar className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
           </div>
@@ -123,7 +123,7 @@ export default function BasicInfoSection({
               value={workPeriodEnd}
               onChange={(e) => onDateChange('end', e.target.value)}
               disabled={disableEndDate}
-              className="px-4 py-2 pr-10 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 disabled:bg-gray-100 disabled:text-slate-500"
+              className="px-4 py-2 pr-10 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 disabled:bg-gray-100 disabled:text-slate-500"
             />
             <Calendar className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
           </div>

--- a/apps/admin-web/src/pages/risk-assessment/components/BasicInfoSection.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/components/BasicInfoSection.tsx
@@ -78,38 +78,30 @@ export default function BasicInfoSection({
         <span className="text-slate-800">{siteName}</span>
       </div>
 
-      <div>
-        <label className="block text-base font-medium text-slate-600 mb-2">소속</label>
-        <div className="space-y-3">
-          {/* 회사 (고정) */}
-          <div className="flex items-center gap-4">
-            <label className="text-base font-medium text-slate-600 w-20">회사</label>
-            <span className="text-slate-800">{companyName}</span>
-          </div>
-
-          {/* 팀 선택 */}
-          <div className="flex items-center gap-4">
-            <label className="text-base font-medium text-slate-600 w-20">팀(업체)</label>
-            {canChangeTeam && onTeamChange ? (
-              <div className="relative flex-1 max-w-md">
-                <select
-                  value={teamId || 'all'}
-                  onChange={(e) => onTeamChange(e.target.value)}
-                  className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 appearance-none bg-white"
-                >
-                  <option value="all">전체 (팀 미지정)</option>
-                  {teams.map((team) => (
-                    <option key={team.id} value={team.id}>
-                      {team.name}
-                    </option>
-                  ))}
-                </select>
-                <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400 pointer-events-none" />
-              </div>
-            ) : (
-              <span className="text-slate-800">{teamDisplayText}</span>
-            )}
-          </div>
+      <div className="flex items-center gap-4">
+        <label className="text-base font-medium text-slate-600 w-24">소속</label>
+        <div className="flex items-center gap-2 flex-1">
+          <span className="text-slate-800">{companyName}</span>
+          <span className="text-slate-400">/</span>
+          {canChangeTeam && onTeamChange ? (
+            <div className="relative flex-1 max-w-xs">
+              <select
+                value={teamId || 'all'}
+                onChange={(e) => onTeamChange(e.target.value)}
+                className="w-full px-3 py-1.5 pr-8 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 appearance-none bg-white"
+              >
+                <option value="all">전체 (팀 미지정)</option>
+                {teams.map((team) => (
+                  <option key={team.id} value={team.id}>
+                    {team.name}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
+            </div>
+          ) : (
+            <span className="text-slate-800">{teamDisplayText}</span>
+          )}
         </div>
       </div>
 

--- a/apps/admin-web/src/pages/risk-assessment/components/RiskFactorCard.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/components/RiskFactorCard.tsx
@@ -48,7 +48,7 @@ export default function RiskFactorCard({
         <button
           type="button"
           onClick={onDelete}
-          className="flex items-center gap-1 text-sm text-red-500 font-medium hover:text-red-600 transition-colors"
+          className="flex items-center gap-1 text-base text-red-500 font-medium hover:text-red-600 transition-colors"
         >
           <Trash2 size={16} />
           항목 삭제
@@ -57,7 +57,7 @@ export default function RiskFactorCard({
 
       {/* 위험 요인 */}
       <div>
-        <label className="block text-sm font-medium text-slate-600 mb-2">
+        <label className="block text-base font-medium text-slate-600 mb-2">
           위험 요인
         </label>
         <div className="relative">
@@ -66,7 +66,7 @@ export default function RiskFactorCard({
             value={factor}
             onChange={(e) => onChange('factor', e.target.value)}
             placeholder="위험 요인을 입력하세요..."
-            className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
+            className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
           />
           <button
             type="button"
@@ -81,7 +81,7 @@ export default function RiskFactorCard({
       {/* 위험성 수준 */}
       <div>
         <div className="flex items-center gap-6">
-          <span className="text-sm font-medium text-slate-600">위험성 수준</span>
+          <span className="text-base font-medium text-slate-600">위험성 수준</span>
 
           <div className="flex items-center gap-4">
             {[
@@ -98,7 +98,7 @@ export default function RiskFactorCard({
                   onChange={() => onChange('level', option.value)}
                   className="w-4 h-4 text-orange-500 focus:ring-orange-500"
                 />
-                <span className="text-sm text-slate-700">{option.label}</span>
+                <span className="text-base text-slate-700">{option.label}</span>
               </label>
             ))}
           </div>
@@ -107,7 +107,7 @@ export default function RiskFactorCard({
 
       {/* 개선 대책 */}
       <div>
-        <label className="block text-sm font-medium text-slate-600 mb-2">
+        <label className="block text-base font-medium text-slate-600 mb-2">
           개선 대책
         </label>
         <input
@@ -115,13 +115,13 @@ export default function RiskFactorCard({
           value={improvement}
           onChange={(e) => onChange('improvement', e.target.value)}
           placeholder="개선 대책을 입력하세요..."
-          className="w-full px-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
         />
       </div>
 
       {/* 작업 기간 */}
       <div>
-        <label className="block text-sm font-medium text-slate-600 mb-2">
+        <label className="block text-base font-medium text-slate-600 mb-2">
           작업 기간
         </label>
         <div className="flex items-center gap-3">
@@ -130,7 +130,7 @@ export default function RiskFactorCard({
               type="date"
               value={workPeriodStart}
               onChange={(e) => onChange('workPeriodStart', e.target.value)}
-              className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
+              className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
             />
             <Calendar className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
           </div>
@@ -140,7 +140,7 @@ export default function RiskFactorCard({
               type="date"
               value={workPeriodEnd}
               onChange={(e) => onChange('workPeriodEnd', e.target.value)}
-              className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
+              className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg text-base focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
             />
             <Calendar className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
           </div>

--- a/apps/admin-web/src/pages/risk-assessment/components/SubcategoryCheckList.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/components/SubcategoryCheckList.tsx
@@ -5,7 +5,8 @@
  * 복수 선택 가능, 커스텀 소분류 추가 가능
  */
 
-import { CheckCircle, PlusCircle } from 'lucide-react';
+import { useState } from 'react';
+import { CheckCircle, PlusCircle, Search } from 'lucide-react';
 
 interface Subcategory {
   id: number;
@@ -28,6 +29,8 @@ export default function SubcategoryCheckList({
   onChange,
   onAddCustom,
 }: SubcategoryCheckListProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+
   // Mock 데이터 (실제로는 API에서 categoryId로 조회)
   const mockSubcategories: Subcategory[] = [
     { id: 101, name: '가설전선 설치작업' },
@@ -38,6 +41,11 @@ export default function SubcategoryCheckList({
   ];
 
   const allSubcategories = [...mockSubcategories, ...customItems];
+
+  // 검색 필터링
+  const filteredSubcategories = allSubcategories.filter((sub) =>
+    sub.name.toLowerCase().includes(searchQuery.toLowerCase())
+  );
 
   const handleToggle = (id: number) => {
     if (selectedIds.includes(id)) {
@@ -53,35 +61,53 @@ export default function SubcategoryCheckList({
         소분류 선택 <span className="text-slate-400">(한 개 이상 선택하세요)</span>
       </p>
 
+      {/* 검색창 */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400" />
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="소분류 검색..."
+          className="w-full pl-10 pr-4 py-2 border-2 border-gray-200 rounded-lg focus:border-orange-500 focus:outline-none text-sm"
+        />
+      </div>
+
       {/* 체크박스 리스트 */}
       <div className="space-y-2">
-        {allSubcategories.map((sub) => {
-          const isSelected = selectedIds.includes(sub.id);
+        {filteredSubcategories.length > 0 ? (
+          filteredSubcategories.map((sub) => {
+            const isSelected = selectedIds.includes(sub.id);
 
-          return (
-            <label
-              key={sub.id}
-              className="flex items-center gap-3 py-2 px-2 cursor-pointer hover:bg-gray-50 rounded transition-colors"
-            >
-              {isSelected ? (
-                <CheckCircle size={20} className="text-red-500 flex-shrink-0" />
-              ) : (
-                <input
-                  type="checkbox"
-                  checked={false}
-                  onChange={() => handleToggle(sub.id)}
-                  className="w-5 h-5 rounded border-gray-300 text-orange-500 focus:ring-orange-500 focus:ring-offset-0"
-                />
-              )}
-              <span className="text-sm text-slate-700 flex-1">
-                {sub.name}
-                {sub.isCustom && (
-                  <span className="ml-2 text-xs text-orange-600">(직접 추가)</span>
+            return (
+              <label
+                key={sub.id}
+                className="flex items-center gap-3 py-2 px-2 cursor-pointer hover:bg-gray-50 rounded transition-colors"
+              >
+                {isSelected ? (
+                  <CheckCircle size={20} className="text-red-500 flex-shrink-0" />
+                ) : (
+                  <input
+                    type="checkbox"
+                    checked={false}
+                    onChange={() => handleToggle(sub.id)}
+                    className="w-5 h-5 rounded border-gray-300 text-orange-500 focus:ring-orange-500 focus:ring-offset-0"
+                  />
                 )}
-              </span>
-            </label>
-          );
-        })}
+                <span className="text-sm text-slate-700 flex-1">
+                  {sub.name}
+                  {sub.isCustom && (
+                    <span className="ml-2 text-xs text-orange-600">(직접 추가)</span>
+                  )}
+                </span>
+              </label>
+            );
+          })
+        ) : (
+          <div className="py-8 text-center text-slate-400 text-sm">
+            검색 결과가 없습니다
+          </div>
+        )}
       </div>
 
       {/* 소분류 직접 추가 버튼 */}

--- a/apps/admin-web/src/pages/risk-assessment/modals/RiskFactorSelectModal.tsx
+++ b/apps/admin-web/src/pages/risk-assessment/modals/RiskFactorSelectModal.tsx
@@ -5,7 +5,8 @@
  */
 
 import { useState, useEffect } from 'react';
-import { X, Search } from 'lucide-react';
+import { X, Search, Loader2 } from 'lucide-react';
+import { getAIRecommendations, type AIRecommendation } from '@/mocks/ai-recommendations';
 
 interface RiskFactorOption {
   id: number;
@@ -39,6 +40,11 @@ export default function RiskFactorSelectModal({
   const [inputMode, setInputMode] = useState<'search' | 'direct'>('search');
   const [directFactor, setDirectFactor] = useState('');
   const [directImprovement, setDirectImprovement] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [aiRecommendations, setAiRecommendations] = useState<AIRecommendation[]>([]);
+  const [isLoadingAI, setIsLoadingAI] = useState(false);
+
+  const itemsPerPage = 20;
 
   // 모달이 열릴 때 초기 모드 설정
   useEffect(() => {
@@ -46,6 +52,31 @@ export default function RiskFactorSelectModal({
       setInputMode(initialMode);
     }
   }, [isOpen, initialMode]);
+
+  // AI 추천 로딩
+  useEffect(() => {
+    if (isOpen && categoryId !== undefined && subcategoryId !== undefined && !isCustomSubcategory) {
+      loadMockAIRecommendations();
+    } else {
+      setAiRecommendations([]);
+    }
+  }, [isOpen, categoryId, subcategoryId, isCustomSubcategory]);
+
+  // AI 추천 로딩 함수 (Mock)
+  const loadMockAIRecommendations = () => {
+    if (categoryId !== undefined && subcategoryId !== undefined) {
+      setIsLoadingAI(true);
+      const key = `${categoryId}-${subcategoryId}`;
+      console.log('🔍 AI 추천 요청:', { categoryId, subcategoryId, key });
+
+      setTimeout(() => {
+        const recommendations = getAIRecommendations(categoryId, subcategoryId);
+        console.log('📊 AI 추천 결과:', recommendations.length, '개', recommendations);
+        setAiRecommendations(recommendations);
+        setIsLoadingAI(false);
+      }, 800);
+    }
+  };
 
   // Mock 데이터
   const mockFactors: RiskFactorOption[] = [
@@ -84,6 +115,17 @@ export default function RiskFactorSelectModal({
     !existingFactors.includes(f.factor)
   );
 
+  // 페이지네이션 계산
+  const totalPages = Math.ceil(filteredFactors.length / itemsPerPage);
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const endIndex = startIndex + itemsPerPage;
+  const paginatedFactors = filteredFactors.slice(startIndex, endIndex);
+
+  // 검색어 변경 시 페이지 초기화
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery]);
+
   if (!isOpen) return null;
 
   const handleToggle = (id: number) => {
@@ -98,10 +140,16 @@ export default function RiskFactorSelectModal({
     let result: { factor: string; improvement: string }[] = [];
 
     if (inputMode === 'search') {
-      // 검색 모드: 선택된 항목들
-      result = mockFactors
+      // 검색 모드: AI 추천 + 일반 선택 항목들
+      const aiFactors = aiRecommendations
+        .filter(ai => selectedIds.includes(ai.id))
+        .map(ai => ({ factor: ai.riskFactor, improvement: ai.improvement }));
+
+      const regularFactors = mockFactors
         .filter(f => selectedIds.includes(f.id))
         .map(f => ({ factor: f.factor, improvement: f.improvement }));
+
+      result = [...aiFactors, ...regularFactors];
     } else {
       // 직접 입력 모드: 입력한 항목
       if (directFactor.trim() && directImprovement.trim()) {
@@ -124,6 +172,8 @@ export default function RiskFactorSelectModal({
     setInputMode('search');
     setDirectFactor('');
     setDirectImprovement('');
+    setCurrentPage(1);
+    setAiRecommendations([]);
     onClose();
   };
 
@@ -133,6 +183,8 @@ export default function RiskFactorSelectModal({
     setInputMode('search');
     setDirectFactor('');
     setDirectImprovement('');
+    setCurrentPage(1);
+    setAiRecommendations([]);
     onClose();
   };
 
@@ -186,114 +238,208 @@ export default function RiskFactorSelectModal({
           </button>
         </div>
 
-        {inputMode === 'search' ? (
-          <>
-            {isCustomSubcategory ? (
-              /* 커스텀 소분류는 추천 목록 없음 */
-              <div className="flex-1 flex items-center justify-center py-16 mb-4">
-                <div className="text-center">
+        {/* 스크롤 가능한 콘텐츠 영역 */}
+        <div className="flex-1 overflow-y-auto mb-4">
+          {inputMode === 'search' ? (
+            <>
+              {isCustomSubcategory ? (
+                /* 커스텀 소분류는 추천 목록 없음 */
+                <div className="flex items-center justify-center py-16">
+                  <div className="text-center">
+                    <div className="mb-4">
+                      <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                    </div>
+                    <h3 className="text-lg font-medium text-slate-700 mb-2">
+                      해당 소분류에 따른 위험요인 추천이 없습니다
+                    </h3>
+                    <p className="text-sm text-slate-500 mb-4">
+                      직접 추가한 소분류는 위험요인 추천 목록이 제공되지 않습니다.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => setInputMode('direct')}
+                      className="px-6 py-2 rounded-lg font-medium text-white bg-orange-500 hover:bg-orange-600 transition-colors"
+                    >
+                      직접 입력하기
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  {/* 검색 */}
                   <div className="mb-4">
-                    <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                    </svg>
+                    <div className="flex items-center px-4 py-2 border border-gray-300 rounded-lg focus-within:border-orange-500 focus-within:ring-1 focus-within:ring-orange-500">
+                      <Search size={18} className="text-slate-400 mr-2" />
+                      <input
+                        type="text"
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        placeholder="위험요인 검색..."
+                        className="flex-1 text-sm bg-transparent focus:outline-none"
+                      />
+                    </div>
                   </div>
-                  <h3 className="text-lg font-medium text-slate-700 mb-2">
-                    해당 소분류에 따른 위험요인 추천이 없습니다
-                  </h3>
-                  <p className="text-sm text-slate-500 mb-4">
-                    직접 추가한 소분류는 위험요인 추천 목록이 제공되지 않습니다.
-                  </p>
-                  <button
-                    type="button"
-                    onClick={() => setInputMode('direct')}
-                    className="px-6 py-2 rounded-lg font-medium text-white bg-orange-500 hover:bg-orange-600 transition-colors"
-                  >
-                    직접 입력하기
-                  </button>
-                </div>
-              </div>
-            ) : (
-              <>
-                {/* 검색 */}
-                <div className="mb-4">
-                  <div className="flex items-center px-4 py-2 border border-gray-300 rounded-lg focus-within:border-orange-500 focus-within:ring-1 focus-within:ring-orange-500">
-                    <Search size={18} className="text-slate-400 mr-2" />
-                    <input
-                      type="text"
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                      placeholder="위험요인 검색..."
-                      className="flex-1 text-sm bg-transparent focus:outline-none"
-                    />
-                  </div>
-                </div>
 
-                {/* 위험요인 리스트 */}
-                <div className="flex-1 overflow-y-auto border border-gray-200 rounded-lg mb-4">
-                  {filteredFactors.length > 0 ? (
-                    <div className="divide-y divide-gray-200">
-                      {filteredFactors.map((factor) => (
-                        <label
-                          key={factor.id}
-                          className="flex items-start gap-3 p-4 hover:bg-orange-50 cursor-pointer transition-colors"
+                  {/* AI 추천 섹션 */}
+                  {isLoadingAI ? (
+                    <div className="flex items-center justify-center py-8 mb-4">
+                      <Loader2 className="w-6 h-6 text-orange-500 animate-spin mr-2" />
+                      <span className="text-sm text-slate-600">AI 추천 분석 중...</span>
+                    </div>
+                  ) : aiRecommendations.length > 0 ? (
+                    <div className="mb-6">
+                      <div className="flex items-center gap-2 mb-3">
+                        <div className="flex items-center gap-2">
+                          <div className="w-2 h-2 bg-orange-500 rounded-full animate-pulse"></div>
+                          <h3 className="text-sm font-bold text-slate-700 uppercase tracking-wide">
+                            AI 추천 위험요인
+                          </h3>
+                        </div>
+                        <span className="text-xs text-slate-500 bg-orange-50 px-2 py-0.5 rounded-full">
+                          {aiRecommendations.length}개 추천
+                        </span>
+                      </div>
+                      <div className="space-y-2">
+                        {aiRecommendations.map((ai) => (
+                          <label
+                            key={ai.id}
+                            className="flex items-start gap-3 p-3 rounded-lg border-2 border-orange-100 bg-gradient-to-r from-orange-50 to-white hover:border-orange-300 cursor-pointer transition-all"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={selectedIds.includes(ai.id)}
+                              onChange={() => handleToggle(ai.id)}
+                              className="mt-1 w-5 h-5 rounded border-orange-300 text-orange-500 focus:ring-orange-500"
+                            />
+                            <div className="flex-1 min-w-0">
+                              <div className="flex items-start justify-between gap-2 mb-1">
+                                <div className="text-sm font-bold text-slate-800">
+                                  {ai.riskFactor}
+                                </div>
+                                <div className="flex items-center gap-1 shrink-0">
+                                  <span className="text-xs font-bold text-orange-600 bg-orange-100 px-2 py-0.5 rounded">
+                                    {ai.score}점
+                                  </span>
+                                </div>
+                              </div>
+                              <div className="text-xs text-slate-600 mb-1">
+                                개선대책: {ai.improvement}
+                              </div>
+                              <div className="flex items-center gap-2 text-xs">
+                                <span className="text-slate-500">
+                                  재해유형: <span className="font-medium text-slate-700">{ai.accidentType}</span>
+                                </span>
+                                <span className="text-slate-300">•</span>
+                                <span className="text-slate-400 truncate">{ai.reason}</span>
+                              </div>
+                            </div>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {/* 일반 위험요인 리스트 */}
+                  <div>
+                    {aiRecommendations.length > 0 && (
+                      <h3 className="text-sm font-bold text-slate-600 uppercase tracking-wide mb-3">
+                        일반 위험요인
+                      </h3>
+                    )}
+                    <div className="border border-gray-200 rounded-lg">
+                      {paginatedFactors.length > 0 ? (
+                        <div className="divide-y divide-gray-200">
+                          {paginatedFactors.map((factor) => (
+                            <label
+                              key={factor.id}
+                              className="flex items-start gap-3 p-4 hover:bg-orange-50 cursor-pointer transition-colors"
+                            >
+                              <input
+                                type="checkbox"
+                                checked={selectedIds.includes(factor.id)}
+                                onChange={() => handleToggle(factor.id)}
+                                className="mt-1 w-5 h-5 rounded border-gray-300 text-orange-500 focus:ring-orange-500"
+                              />
+                              <div className="flex-1">
+                                <div className="text-sm font-medium text-slate-800 mb-1">
+                                  {factor.factor}
+                                </div>
+                                <div className="text-xs text-slate-500">
+                                  개선대책: {factor.improvement}
+                                </div>
+                              </div>
+                            </label>
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="p-12 text-center text-slate-400">
+                          검색 결과가 없습니다
+                        </div>
+                      )}
+                    </div>
+
+                    {/* 페이지네이션 */}
+                    {totalPages > 1 && (
+                      <div className="flex items-center justify-center gap-2 mt-4">
+                        <button
+                          type="button"
+                          onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
+                          disabled={currentPage === 1}
+                          className="px-3 py-1 text-sm rounded-lg border border-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
                         >
-                          <input
-                            type="checkbox"
-                            checked={selectedIds.includes(factor.id)}
-                            onChange={() => handleToggle(factor.id)}
-                            className="mt-1 w-5 h-5 rounded border-gray-300 text-orange-500 focus:ring-orange-500"
-                          />
-                          <div className="flex-1">
-                            <div className="text-sm font-medium text-slate-800 mb-1">
-                              {factor.factor}
-                            </div>
-                            <div className="text-xs text-slate-500">
-                              개선대책: {factor.improvement}
-                            </div>
-                          </div>
-                        </label>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="p-12 text-center text-slate-400">
-                      검색 결과가 없습니다
-                    </div>
-                  )}
+                          이전
+                        </button>
+                        <span className="text-sm text-slate-600">
+                          {currentPage} / {totalPages}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
+                          disabled={currentPage === totalPages}
+                          className="px-3 py-1 text-sm rounded-lg border border-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          다음
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+            </>
+          ) : (
+            <>
+              {/* 직접 입력 폼 */}
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-slate-600 mb-2">
+                    위험 요인 <span className="text-red-500">*</span>
+                  </label>
+                  <textarea
+                    value={directFactor}
+                    onChange={(e) => setDirectFactor(e.target.value)}
+                    placeholder="위험 요인을 입력하세요..."
+                    rows={3}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 resize-none"
+                  />
                 </div>
-              </>
-            )}
-          </>
-        ) : (
-          <>
-            {/* 직접 입력 폼 */}
-            <div className="space-y-4 mb-4">
-              <div>
-                <label className="block text-sm font-medium text-slate-600 mb-2">
-                  위험 요인 <span className="text-red-500">*</span>
-                </label>
-                <textarea
-                  value={directFactor}
-                  onChange={(e) => setDirectFactor(e.target.value)}
-                  placeholder="위험 요인을 입력하세요..."
-                  rows={3}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 resize-none"
-                />
+                <div>
+                  <label className="block text-sm font-medium text-slate-600 mb-2">
+                    개선 대책 <span className="text-red-500">*</span>
+                  </label>
+                  <textarea
+                    value={directImprovement}
+                    onChange={(e) => setDirectImprovement(e.target.value)}
+                    placeholder="개선 대책을 입력하세요..."
+                    rows={3}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 resize-none"
+                  />
+                </div>
               </div>
-              <div>
-                <label className="block text-sm font-medium text-slate-600 mb-2">
-                  개선 대책 <span className="text-red-500">*</span>
-                </label>
-                <textarea
-                  value={directImprovement}
-                  onChange={(e) => setDirectImprovement(e.target.value)}
-                  placeholder="개선 대책을 입력하세요..."
-                  rows={3}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500 resize-none"
-                />
-              </div>
-            </div>
-          </>
-        )}
+            </>
+          )}
+        </div>
 
         {/* 버튼 */}
         <div className="flex items-center justify-between">


### PR DESCRIPTION
﻿## 작업 요약

위험성평가 목록/만들기/상세 화면의 UI를 정리하고, 결재라인 표시/선택 UX와 팀(업체) 관련 데이터 구조를 개선했습니다.

---

## 주요 변경사항

### 1) 목록/상세 UI 정리
- 목록 테이블에서 `결재사항` 컬럼 제거 (7개 -> 6개 컬럼)
- 상세 화면에서 문서번호 UI 제거 (내부 `documentId` 변수는 유지)
- 신규 생성 문서의 기본 상태를 `PENDING`으로 생성하도록 정리

### 2) 소속(회사/팀) UX 개선
- 기본정보의 소속 영역을 `회사 / 팀` 한 줄 레이아웃으로 정리
- 팀 선택 드롭다운 추가 (`전체(팀 미지정)` 포함)
- 팀 Mock 데이터 추가 (`apps/admin-web/src/mocks/teams.ts`)

### 3) 결재라인 개선
- `ApprovalLine` 타입에 `teamId` 필드 추가
- 결재라인 목록/선택 UI에서 공용/팀 전용 배지 표시
- 결재자 미리보기 테이블 컴포넌트 추가 (`ApproverPreviewTable`)
- 결재라인 테이블 컴포넌트 추가 (`ApprovalLineDisplay`)
  - `preview` / `document` 모드 지원
  - `document` 모드에서 서명 영역 표시

### 4) 위험요인 선택 모달 개선
- AI 추천 Mock 데이터 연동 (`apps/admin-web/src/mocks/ai-recommendations.ts`)
- 추천 섹션/일반 목록 시각 구분 강화
- 검색, 페이지네이션, 선택 UX 개선
- 소분류 검색 기능 추가

### 5) 접근/동선 로직 정리
- 목록에서 `INITIAL` 유형은 상세보기 진입 허용
- 미지원 유형의 만들기/상세 진입 시 안내 메시지 노출 유지

---

## 변경 파일/규모

브랜치 커밋 범위(`46869cd^..fc920ed`) 기준:
- **31 files changed**
- **+4635 / -566**

### 신규 주요 파일
- `apps/admin-web/src/components/approval/ApprovalLineDisplay.tsx`
- `apps/admin-web/src/components/common/ApproverPreviewTable.tsx`
- `apps/admin-web/src/mocks/teams.ts`
- `apps/admin-web/src/mocks/ai-recommendations.ts`

### 주요 수정 파일
- `apps/admin-web/src/pages/RiskAssessmentPage.tsx`
- `apps/admin-web/src/components/risk-assessment/forms/InitialAssessmentForm.tsx`
- `apps/admin-web/src/pages/risk-assessment/components/BasicInfoSection.tsx`
- `apps/admin-web/src/pages/risk-assessment/modals/RiskFactorSelectModal.tsx`
- `apps/admin-web/src/pages/risk-assessment/modals/ApprovalLineSelectModal.tsx`
- `apps/admin-web/src/components/settings/ApprovalLineSettings.tsx`
- `apps/admin-web/src/pages/risk-assessment/RiskAssessmentDetailPage.tsx`
- `packages/shared/src/types/approval.ts`

---

## 커밋 내역 (10개)

```text
fc920ed chore: .gitignore 업데이트 - 빌드 캐시 및 로컬 설정 파일 제외
665e912 feat: 위험성평가 테이블 정리 및 UI 개선
4007c14 fix: InitialAssessmentForm에 팀 선택 기능 추가
cc3be0e refactor: 소속 항목 레이아웃 한 줄로 압축
9441f46 feat: 위험성평가 소속 항목에 팀 선택 기능 추가
55dae14 style: 위험성평가 페이지 글자 크기 125% 증가
fa41277 feat: 위험요인 선택 모달 AI 추천 및 레이아웃 개선
3c117ad feat: 위험성평가 UI 개선 - 소분류 검색, 페이지네이션, AI 추천
f6e4e7f feat: 위험성평가 결재라인 UI 개선
46869cd feat: 결재라인 팀 태그 및 컴포넌트화
```

---

## 수동 확인 항목

### 목록 페이지
- [x] 6개 컬럼 표시
- [x] 상태 배지 표시 및 정렬 확인
- [x] INITIAL 유형 상세 진입 동작

### 만들기 페이지
- [x] 소속(회사/팀) 1줄 표시
- [x] 팀 드롭다운 동작
- [x] 결재라인 선택 모달(테이블 미리보기) 동작
- [x] 위험요인 모달 검색/페이지네이션/AI 추천 표시 동작

### 상세 페이지
- [x] 문서번호 미표시
- [x] 결재라인 테이블 표시
- [x] document 모드 서명 영역 표시

### 설정 페이지
- [x] 결재라인 팀 선택/배지 표시
- [x] 결재자 미리보기 테이블 표시

---

## 문서

- `.sisyphus/plans/risk-assessment-table-cleanup.md`
- `.sisyphus/drafts/initial-risk-assessment-improvements.md`
- `.sisyphus/drafts/risk-assessment-ui-improvements.md`
- `.sisyphus/logs/2026-01-26-risk-assessment-table-cleanup.md`
- `.sisyphus/logs/2026-01-26-risk-assessment-font-size-increase.md`
- `.sisyphus/logs/2026-01-26-risk-assessment-team-selection.md`

---

## 비고

- 개발 서버: `http://localhost:5173/`
- 현재는 Mock 데이터 기반이며, 실제 API/DB 연동은 후속 작업 예정

Generated with [Claude Code](https://claude.com/claude-code)
